### PR TITLE
Add support for URL shortening

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [7.3, 7.4, 8.0]
+        php: [7.4, 8.0]
 
     name: P${{ matrix.php }} - ${{ matrix.os }}
 

--- a/app/Http/Controllers/Api/UrlController.php
+++ b/app/Http/Controllers/Api/UrlController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Url;
+use Illuminate\Http\Request;
+
+class UrlController extends Controller
+{
+    /**
+     * Setup the image policy used in the controller for authorization.
+     */
+    public function __construct()
+    {
+        $this->authorizeResource(Url::class);
+    }
+
+    /**
+     * Display a listing of the resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function index(Request $request)
+    {
+        return Url::paginate(10);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \App\Http\Requests\TextUploadRequest  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        $url = Url::createAndSave($request->get('url'));
+
+        if ($request->header('Accept') == 'text/plain') {
+            $url = $url->resource_url;
+        }
+
+        return response($url, 201);
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \App\Models\Url  $url
+     * @return \Illuminate\Http\Response
+     */
+    public function show(Url $url)
+    {
+        return $url;
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \App\Models\Url  $url
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(Url $url)
+    {
+        $url->delete();
+
+        return response(null, 204);
+    }
+}

--- a/app/Http/Controllers/Api/UrlController.php
+++ b/app/Http/Controllers/Api/UrlController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\UrlUploadRequest;
 use App\Models\Url;
 use Illuminate\Http\Request;
 
@@ -30,10 +31,10 @@ class UrlController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @param  \App\Http\Requests\TextUploadRequest  $request
+     * @param  \App\Http\Requests\UrlUploadRequest  $request
      * @return \Illuminate\Http\Response
      */
-    public function store(Request $request)
+    public function store(UrlUploadRequest $request)
     {
         $url = Url::createAndSave($request->get('url'));
 

--- a/app/Http/Controllers/RenderUrlController.php
+++ b/app/Http/Controllers/RenderUrlController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class RenderUrlController extends Controller
+{
+    /**
+     * Handle the incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function __invoke(Request $request)
+    {
+        // TODO: Render url here...
+    }
+}

--- a/app/Http/Controllers/RenderUrlController.php
+++ b/app/Http/Controllers/RenderUrlController.php
@@ -9,10 +9,11 @@ class RenderUrlController extends Controller
     /**
      * Handle the incoming request.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  string $id
+     * @param  string|null $preview
      * @return \Illuminate\Http\Response
      */
-    public function __invoke(Request $request)
+    public function __invoke($id, $preview = null)
     {
         // TODO: Render url here...
     }

--- a/app/Http/Controllers/RenderUrlController.php
+++ b/app/Http/Controllers/RenderUrlController.php
@@ -27,6 +27,8 @@ class RenderUrlController extends Controller
             return $this->createPreview($url);
         }
 
+        $url->increment('visits');
+
         return redirect($url->url);
     }
 

--- a/app/Http/Livewire/ControlPanel/UpdateUrlSettingsForm.php
+++ b/app/Http/Livewire/ControlPanel/UpdateUrlSettingsForm.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Http\Livewire\ControlPanel;
+
+use Livewire\Component;
+
+class UpdateUrlSettingsForm extends Component
+{
+    /**
+     * The url settings.
+     *
+     * @var array
+     */
+    public $settings;
+
+    /**
+     * The validation rules for the component.
+     *
+     * @var array
+     */
+    protected $rules = [
+        'settings.ttl_days' => 'required|numeric|min:0',
+        'settings.ttl_hours' => 'required|numeric|min:0',
+        'settings.ttl_minutes' => 'required|numeric|min:0',
+        'settings.per_page' => 'required|numeric|min:1',
+    ];
+
+    /**
+     * List of validation attribute names that are more human friendly.
+     *
+     * @var array
+     */
+    protected $validationAttributes = [
+        'settings.ttl_days' => 'TTL days',
+        'settings.ttl_hours' => 'TTL hours',
+        'settings.ttl_minutes' => 'TTL minutes',
+        'settings.per_page' => 'shorten URLs per page',
+    ];
+
+    /**
+     * Prepare the component.
+     *
+     * @return void
+     */
+    public function mount()
+    {
+        $settings = app('settings');
+
+        $this->settings = [
+            'ttl_days' => $settings->get('urls.ttl_days'),
+            'ttl_hours' => $settings->get('urls.ttl_hours'),
+            'ttl_minutes' => $settings->get('urls.ttl_minutes'),
+            'per_page' => $settings->get('urls.per_page'),
+        ];
+    }
+
+    /**
+     * Update the url settings.
+     *
+     * @return void
+     */
+    public function updateUrlSettings()
+    {
+        $this->validate();
+
+        $manager = app('settings');
+
+        foreach ($this->settings as $name => $value) {
+            $manager->set('urls.' . $name, $value);
+        }
+
+        $this->emit('saved');
+    }
+
+    /**
+     * Render the component.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function render()
+    {
+        return view('control-panel.update-url-settings-form');
+    }
+}

--- a/app/Http/Livewire/Url/PaginatedUrlList.php
+++ b/app/Http/Livewire/Url/PaginatedUrlList.php
@@ -25,7 +25,9 @@ class PaginatedUrlList extends Component
     public function render()
     {
         return view('url.paginated-url-list', [
-            'urls' => Url::latest()->paginate(24),
+            'urls' => Url::latest()->paginate(
+                app('settings')->get('urls.per_page')
+            ),
         ]);
     }
 }

--- a/app/Http/Livewire/Url/PaginatedUrlList.php
+++ b/app/Http/Livewire/Url/PaginatedUrlList.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Livewire\Url;
+
+use App\Models\Url;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class PaginatedUrlList extends Component
+{
+    use WithPagination;
+
+    /**
+     * The events the component should listen for.
+     *
+     * @var array
+     */
+    protected $listeners = ['urlDeleted' => '$refresh'];
+
+    /**
+     * Render the component.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function render()
+    {
+        return view('url.paginated-url-list', [
+            'urls' => Url::latest()->paginate(24),
+        ]);
+    }
+}

--- a/app/Http/Livewire/Url/UrlPreview.php
+++ b/app/Http/Livewire/Url/UrlPreview.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Livewire\Url;
+
+use Livewire\Component;
+
+class UrlPreview extends Component
+{
+    /**
+     * The url the component previews.
+     *
+     * @var \App\Models\Url
+     */
+    public $url;
+
+    /**
+     * Deletes the url associated with the component.
+     *
+     * @return void
+     */
+    public function delete()
+    {
+        $this->url->delete();
+
+        $this->emitUp('urlDeleted');
+    }
+
+    /**
+     * Render the component.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function render()
+    {
+        return view('url.url-preview', [
+            'url' => $this->url,
+        ]);
+    }
+}

--- a/app/Http/Livewire/Url/UrlPreviewList.php
+++ b/app/Http/Livewire/Url/UrlPreviewList.php
@@ -23,8 +23,20 @@ class UrlPreviewList extends Component
     {
         return view('url.url-preview-list', [
             'urls' => Url::latest()
-                ->limit(12)
+                ->limit($this->getUrlsPerPageSize())
                 ->get(),
         ]);
+    }
+
+    /**
+     * Gets the amount of shorten URLs that should be shown per page, and
+     * divides it by half, if the value is larger than 12 we just cap
+     * the urls shown per page at 12.
+     *
+     * @return int
+     */
+    protected function getUrlsPerPageSize()
+    {
+        return min(app('settings')->get('urls.per_page') / 2, 12);
     }
 }

--- a/app/Http/Livewire/Url/UrlPreviewList.php
+++ b/app/Http/Livewire/Url/UrlPreviewList.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Livewire\Url;
+
+use App\Models\Url;
+use Livewire\Component;
+
+class UrlPreviewList extends Component
+{
+    /**
+     * The events the component should listen for.
+     *
+     * @var array
+     */
+    protected $listeners = ['urlDeleted' => '$refresh'];
+
+    /**
+     * Render the component.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function render()
+    {
+        return view('url.url-preview-list', [
+            'urls' => Url::latest()
+                ->limit(12)
+                ->get(),
+        ]);
+    }
+}

--- a/app/Http/Requests/UrlUploadRequest.php
+++ b/app/Http/Requests/UrlUploadRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Requests;
+
+class UrlUploadRequest extends ApiRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'url' => ['required', 'string', 'url'],
+        ];
+    }
+}

--- a/app/Jobs/GenerateUrlPreview.php
+++ b/app/Jobs/GenerateUrlPreview.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Storage;
+use Spatie\Browsershot\Browsershot;
+use Spatie\Image\Manipulations;
+
+class GenerateUrlPreview implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * The URL that the preview should be generated for.
+     *
+     * @var string
+     */
+    public $url;
+
+    /**
+     * The number of seconds the job can run before timing out.
+     *
+     * @var int
+     */
+    public $timeout = 30;
+
+    /**
+     * The number of times the job may be attempted.
+     *
+     * @var int
+     */
+    public $tries = 5;
+
+    /**
+     * Create a new job instance.
+     *
+     * @param  $url
+     * @return void
+     */
+    public function __construct($url)
+    {
+        $this->url = $url;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if (!Storage::exists('url-previews')) {
+            Storage::makeDirectory('url-previews');
+        }
+
+        Browsershot::url($this->url)
+            ->noSandbox()
+            ->windowSize(640, 480)
+            ->fit(Manipulations::FIT_CONTAIN, 256, 256)
+            ->setScreenshotType('jpeg', 100)
+            ->save(storage_path('app/url-previews/some-unique-id.jpg'));
+    }
+}

--- a/app/Jobs/GenerateUrlPreview.php
+++ b/app/Jobs/GenerateUrlPreview.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Models\Url;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -19,9 +20,9 @@ class GenerateUrlPreview implements ShouldQueue
     /**
      * The URL that the preview should be generated for.
      *
-     * @var string
+     * @var \App\Models\Url
      */
-    public $url;
+    public $model;
 
     /**
      * The number of seconds the job can run before timing out.
@@ -40,12 +41,12 @@ class GenerateUrlPreview implements ShouldQueue
     /**
      * Create a new job instance.
      *
-     * @param  $url
+     * @param  \App\Models\Url $url
      * @return void
      */
-    public function __construct($url)
+    public function __construct(Url $url)
     {
-        $this->url = $url;
+        $this->model = $url;
     }
 
     /**
@@ -55,15 +56,15 @@ class GenerateUrlPreview implements ShouldQueue
      */
     public function handle()
     {
-        if (!Storage::exists('url-previews')) {
-            Storage::makeDirectory('url-previews');
+        if (!Storage::exists('urls')) {
+            Storage::makeDirectory('urls');
         }
 
-        Browsershot::url($this->url)
+        Browsershot::url($this->model->url)
             ->noSandbox()
             ->windowSize(640, 480)
             ->fit(Manipulations::FIT_CONTAIN, 256, 256)
             ->setScreenshotType('jpeg', 100)
-            ->save(storage_path('app/url-previews/some-unique-id.jpg'));
+            ->save(storage_path('app/urls/' . $this->model->name . '.jpg'));
     }
 }

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Models;
+
+use App\Identifier\IdentifierContract;
+use App\Traits\BelongsToUser;
+use App\Traits\MediaResource;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\UploadedFile;
+
+class Url extends Model
+{
+    use HasFactory;
+    use MediaResource;
+    use BelongsToUser;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = ['user_id', 'name', 'url'];
+
+    /**
+     * The name of the route used to view the resource directly.
+     *
+     * @var string
+     */
+    protected $resourceViewRoute = 'view-url';
+
+    /**
+     * The API resource name, this is the API resource name
+     * used when registering the route in the API.
+     *
+     * @var string
+     */
+    protected $resourceApiName = 'urls';
+
+    /**
+     * The belongs to relationship between the image and the user who owns it.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function owner()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    /**
+     * Creates a new url entry, and stores url
+     *
+     * @param  string $url
+     * @return \App\Models\Image
+     */
+    public static function createAndSave(string $url)
+    {
+        return self::create([
+            'user_id' => auth()->user()->id,
+            'name' => app(IdentifierContract::class)->generate(),
+            'url' => $url,
+        ]);
+    }
+}

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -7,7 +7,6 @@ use App\Traits\BelongsToUser;
 use App\Traits\MediaResource;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
 
 class Url extends Model

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -8,6 +8,7 @@ use App\Traits\MediaResource;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Arr;
 
 class Url extends Model
 {
@@ -60,5 +61,27 @@ class Url extends Model
             'name' => app(IdentifierContract::class)->generate(),
             'url' => $url,
         ]);
+    }
+
+    /**
+     * Creates a URL to the direct resource using the
+     * shortest URL defined of all the domains.
+     *
+     * @return string
+     */
+    public function getResourceUrlAttribute()
+    {
+        $url = route($this->resourceViewRoute, $this);
+
+        $domain = collect(app('settings')->get('app.domains'), url('/'))
+            ->sort(fn($first, $second) => strlen($first) > strlen($second))
+            ->flatten()
+            ->get(0);
+
+        if ($domain == null) {
+            return $url;
+        }
+
+        return str_replace(url('/'), $domain, $url);
     }
 }

--- a/app/Observers/UrlObserver.php
+++ b/app/Observers/UrlObserver.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Observers;
+
+use App\Jobs\GenerateUrlPreview;
+use App\Models\Url;
+use Illuminate\Support\Facades\Storage;
+
+class UrlObserver
+{
+    /**
+     * Handle the Url "created" event.
+     *
+     * @param  \App\Models\Url  $url
+     * @return void
+     */
+    public function created(Url $url)
+    {
+        GenerateUrlPreview::dispatch($url);
+    }
+
+    /**
+     * Handle the Url "deleted" event.
+     *
+     * @param  \App\Models\Url  $url
+     * @return void
+     */
+    public function deleted(Url $url)
+    {
+        Storage::delete('urls/' . $image->name . '.jpg');
+    }
+}

--- a/app/Observers/UrlObserver.php
+++ b/app/Observers/UrlObserver.php
@@ -27,6 +27,6 @@ class UrlObserver
      */
     public function deleted(Url $url)
     {
-        Storage::delete('urls/' . $image->name . '.jpg');
+        Storage::delete('urls/' . $url->name . '.jpg');
     }
 }

--- a/app/Policies/UrlPolicy.php
+++ b/app/Policies/UrlPolicy.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Url;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class UrlPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any models.
+     *
+     * @param  \App\Models\User  $user
+     * @return mixed
+     */
+    public function viewAny(User $user)
+    {
+        return $user->tokenCan('url:list');
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Url  $url
+     * @return mixed
+     */
+    public function view(User $user, Url $url)
+    {
+        return $user->tokenCan('url:view') && $user->id == $url->user_id;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     *
+     * @param  \App\Models\User  $user
+     * @return mixed
+     */
+    public function create(User $user)
+    {
+        return $user->tokenCan('url:upload');
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Url  $url
+     * @return mixed
+     */
+    public function delete(User $user, Url $url)
+    {
+        return $user->tokenCan('url:delete') && $user->id == $url->user_id;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,7 +3,9 @@
 namespace App\Providers;
 
 use App\Models\Image;
+use App\Models\Url;
 use App\Observers\ImageObserver;
+use App\Observers\UrlObserver;
 use App\Settings\SettingsManager;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
@@ -32,5 +34,6 @@ class AppServiceProvider extends ServiceProvider
         });
 
         Image::observe(ImageObserver::class);
+        Url::observe(UrlObserver::class);
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -4,8 +4,10 @@ namespace App\Providers;
 
 use App\Models\Image;
 use App\Models\Text;
+use App\Models\Url;
 use App\Policies\ImagePolicy;
 use App\Policies\TextPolicy;
+use App\Policies\UrlPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
 
@@ -19,6 +21,7 @@ class AuthServiceProvider extends ServiceProvider
     protected $policies = [
         Image::class => ImagePolicy::class,
         Text::class => TextPolicy::class,
+        Url::class => UrlPolicy::class,
     ];
 
     /**

--- a/app/Providers/JetstreamServiceProvider.php
+++ b/app/Providers/JetstreamServiceProvider.php
@@ -48,6 +48,10 @@ class JetstreamServiceProvider extends ServiceProvider
             'text:list',
             'text:upload',
             'text:delete',
+            'url:view',
+            'url:list',
+            'url:upload',
+            'url:delete',
         ]);
     }
 }

--- a/app/Settings/SettingsManager.php
+++ b/app/Settings/SettingsManager.php
@@ -18,14 +18,21 @@ class SettingsManager
         'app.url_generator' => 'characters',
         'app.domains' => [],
         'app.theme' => 'light',
+
         'images.ttl_days' => 90,
         'images.ttl_hours' => 0,
         'images.ttl_minutes' => 0,
         'images.per_page' => 24,
+
         'texts.ttl_days' => 30,
         'texts.ttl_hours' => 0,
         'texts.ttl_minutes' => 0,
         'texts.per_page' => 24,
+
+        'urls.ttl_days' => 90,
+        'urls.ttl_hours' => 0,
+        'urls.ttl_minutes' => 0,
+        'urls.per_page' => 24,
     ];
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "laravel/jetstream": "^2.2",
         "laravel/sanctum": "^2.6",
         "laravel/tinker": "^2.5",
-        "livewire/livewire": "^2.0"
+        "livewire/livewire": "^2.0",
+        "spatie/browsershot": "^3.44"
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5f7537e828f5e1f6e933df9700a96538",
+    "content-hash": "1a20688c25a2f0813ad641533508ae36",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1874,6 +1874,71 @@
             "time": "2020-08-23T07:39:11+00:00"
         },
         {
+            "name": "league/glide",
+            "version": "1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/glide.git",
+                "reference": "ae5e26700573cb678919d28e425a8b87bc71c546"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/glide/zipball/ae5e26700573cb678919d28e425a8b87bc71c546",
+                "reference": "ae5e26700573cb678919d28e425a8b87bc71c546",
+                "shasum": ""
+            },
+            "require": {
+                "intervention/image": "^2.4",
+                "league/flysystem": "^1.0",
+                "php": "^7.2|^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.3.3",
+                "phpunit/php-token-stream": "^3.1|^4.0",
+                "phpunit/phpunit": "^8.5|^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Glide\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Reinink",
+                    "email": "jonathan@reinink.ca",
+                    "homepage": "http://reinink.ca"
+                }
+            ],
+            "description": "Wonderfully easy on-demand image manipulation library with an HTTP based API.",
+            "homepage": "http://glide.thephpleague.com",
+            "keywords": [
+                "ImageMagick",
+                "editing",
+                "gd",
+                "image",
+                "imagick",
+                "league",
+                "manipulation",
+                "processing"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/glide/issues",
+                "source": "https://github.com/thephpleague/glide/tree/1.7.0"
+            },
+            "time": "2020-11-05T17:34:03+00:00"
+        },
+        {
             "name": "league/mime-type-detection",
             "version": "1.7.0",
             "source": {
@@ -3158,6 +3223,244 @@
                 }
             ],
             "time": "2020-08-18T17:17:46+00:00"
+        },
+        {
+            "name": "spatie/browsershot",
+            "version": "3.44.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/browsershot.git",
+                "reference": "94815d30e61dfe0f833fe705c82f6c27b484041f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/browsershot/zipball/94815d30e61dfe0f833fe705c82f6c27b484041f",
+                "reference": "94815d30e61dfe0f833fe705c82f6c27b484041f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0",
+                "spatie/image": "^1.5.3",
+                "spatie/temporary-directory": "^1.1",
+                "symfony/process": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0",
+                "spatie/phpunit-snapshot-assertions": "^4.2.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Browsershot\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://github.com/freekmurze",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Convert a webpage to an image or pdf using headless Chrome",
+            "homepage": "https://github.com/spatie/browsershot",
+            "keywords": [
+                "chrome",
+                "convert",
+                "headless",
+                "image",
+                "pdf",
+                "puppeteer",
+                "screenshot",
+                "webpage"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/browsershot/issues",
+                "source": "https://github.com/spatie/browsershot/tree/3.44.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-02-05T08:07:26+00:00"
+        },
+        {
+            "name": "spatie/image",
+            "version": "1.10.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/image.git",
+                "reference": "12662673fbe649bffcd3a24188a404dc31fa118c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/image/zipball/12662673fbe649bffcd3a24188a404dc31fa118c",
+                "reference": "12662673fbe649bffcd3a24188a404dc31fa118c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-exif": "*",
+                "ext-mbstring": "*",
+                "league/glide": "^1.6",
+                "php": "^7.2|^8.0",
+                "spatie/image-optimizer": "^1.1",
+                "spatie/temporary-directory": "^1.0",
+                "symfony/process": "^3.0|^4.0|^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.0|^9.0",
+                "symfony/var-dumper": "^4.0|^5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Image\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Manipulate images with an expressive API",
+            "homepage": "https://github.com/spatie/image",
+            "keywords": [
+                "image",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/image/issues",
+                "source": "https://github.com/spatie/image/tree/1.10.2"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-01-26T07:53:19+00:00"
+        },
+        {
+            "name": "spatie/image-optimizer",
+            "version": "1.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/image-optimizer.git",
+                "reference": "6aa170eb292758553d332efee5e0c3977341080c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/image-optimizer/zipball/6aa170eb292758553d332efee5e0c3977341080c",
+                "reference": "6aa170eb292758553d332efee5e0c3977341080c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "php": "^7.2|^8.0",
+                "psr/log": "^1.0",
+                "symfony/process": "^4.2|^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.0|^9.0",
+                "symfony/var-dumper": "^4.2|^5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\ImageOptimizer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Easily optimize images using PHP",
+            "homepage": "https://github.com/spatie/image-optimizer",
+            "keywords": [
+                "image-optimizer",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/image-optimizer/issues",
+                "source": "https://github.com/spatie/image-optimizer/tree/1.3.2"
+            },
+            "time": "2020-11-28T12:37:58+00:00"
+        },
+        {
+            "name": "spatie/temporary-directory",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/temporary-directory.git",
+                "reference": "f517729b3793bca58f847c5fd383ec16f03ffec6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/temporary-directory/zipball/f517729b3793bca58f847c5fd383ec16f03ffec6",
+                "reference": "f517729b3793bca58f847c5fd383ec16f03ffec6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.0|^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\TemporaryDirectory\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Vanderbist",
+                    "email": "alex@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Easily create, use and destroy temporary directories",
+            "homepage": "https://github.com/spatie/temporary-directory",
+            "keywords": [
+                "php",
+                "spatie",
+                "temporary-directory"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/temporary-directory/issues",
+                "source": "https://github.com/spatie/temporary-directory/tree/1.3.0"
+            },
+            "time": "2020-11-09T15:54:21+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",

--- a/database/factories/UrlFactory.php
+++ b/database/factories/UrlFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Url;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class UrlFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Url::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'user_id' => User::factory(),
+            'name' => Str::random(10),
+            'url' => $this->faker->url,
+        ];
+    }
+}

--- a/database/migrations/2021_03_05_140254_create_urls_table.php
+++ b/database/migrations/2021_03_05_140254_create_urls_table.php
@@ -24,6 +24,7 @@ class CreateUrlsTable extends Migration
                 ->unique()
                 ->index();
             $table->string('url');
+            $table->integer('visits')->default(0);
             $table->timestamps();
 
             $table->unique(['user_id', 'name']);

--- a/database/migrations/2021_03_05_140254_create_urls_table.php
+++ b/database/migrations/2021_03_05_140254_create_urls_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUrlsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('urls', function (Blueprint $table) {
+            $table->id();
+            $table
+                ->foreignId('user_id')
+                ->constrained()
+                ->onDelete('cascade');
+            $table
+                ->string('name')
+                ->unique()
+                ->index();
+            $table->string('url');
+            $table->timestamps();
+
+            $table->unique(['user_id', 'name']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('urls');
+    }
+}

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
         "postcss": "^8.1.14",
         "postcss-import": "^12.0.1",
         "tailwindcss": "^2.0.1"
+    },
+    "dependencies": {
+        "puppeteer": "^8.0.0"
     }
 }

--- a/resources/views/control-panel/index.blade.php
+++ b/resources/views/control-panel/index.blade.php
@@ -24,6 +24,12 @@
             <x-jet-section-border />
 
             <div class="mt-10 sm:mt-0">
+                @livewire('control-panel.update-url-settings-form')
+            </div>
+
+            <x-jet-section-border />
+
+            <div class="mt-10 sm:mt-0">
                 @livewire('control-panel.user-management-list')
             </div>
         </div>

--- a/resources/views/control-panel/update-url-settings-form.blade.php
+++ b/resources/views/control-panel/update-url-settings-form.blade.php
@@ -1,0 +1,41 @@
+<x-jet-form-section submit="updateUrlSettings">
+    <x-slot name="title">
+        {{ __('Url Settings') }}
+    </x-slot>
+
+    <x-slot name="description">
+        {{ __('Change how shorten URLs are handled and displayed on the site.') }}
+    </x-slot>
+
+    <x-slot name="form">
+        <!-- TTL -->
+        <div class="col-span-6 sm:col-span-4">
+            <x-jet-label for="url_ttl_days" value="{{ __('Text Files Live Time (Days, Hours and Minutes)') }}" />
+            <div class="flex space-x-3">
+                <x-jet-input id="url_ttl_days" type="number" class="mt-1 block w-full" min="0" wire:model.defer="settings.ttl_days" />
+                <x-jet-input id="url_ttl_hours" type="number" class="mt-1 block w-full" min="0" wire:model.defer="settings.ttl_hours" />
+                <x-jet-input id="url_ttl_minutes" type="number" class="mt-1 block w-full" min="0" wire:model.defer="settings.ttl_minutes" />
+            </div>
+            <x-jet-input-error for="settings.ttl_days" class="mt-2" />
+            <x-jet-input-error for="settings.ttl_hours" class="mt-2" />
+            <x-jet-input-error for="settings.ttl_minutes" class="mt-2" />
+        </div>
+
+        <!-- Per page -->
+        <div class="col-span-6 sm:col-span-4">
+            <x-jet-label for="url_per_page" value="{{ __('Text files per page') }}" />
+            <x-jet-input id="url_per_page" type="number" class="mt-1 block w-full" min="1" wire:model.defer="settings.per_page" />
+            <x-jet-input-error for="settings.per_page" class="mt-2" />
+        </div>
+    </x-slot>
+
+    <x-slot name="actions">
+        <x-jet-action-message class="mr-3" on="saved">
+            {{ __('Saved.') }}
+        </x-jet-action-message>
+
+        <x-jet-button wire:loading.attr="disabled" wire:target="photo">
+            {{ __('Save') }}
+        </x-jet-button>
+    </x-slot>
+</x-jet-form-section>

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -8,4 +8,6 @@
     @livewire('images.image-preview-list')
 
     @livewire('text.text-preview-list')
+
+    @livewire('url.url-preview-list')
 </x-app-layout>

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -27,6 +27,10 @@
                         {{ __('Texts') }}
                     </x-jet-nav-link>
 
+                    <x-jet-nav-link href="{{ route('urls') }}" :active="request()->routeIs('urls')">
+                        {{ __('URLs') }}
+                    </x-jet-nav-link>
+
                     @if(request()->user()->is_admin)
                         <x-jet-nav-link href="{{ route('control-panel') }}" :active="request()->routeIs('control-panel')">
                             {{ __('Control Panel') }}
@@ -127,6 +131,10 @@
 
             <x-jet-responsive-nav-link href="{{ route('texts') }}" :active="request()->routeIs('texts')">
                 {{ __('Texts') }}
+            </x-jet-responsive-nav-link>
+
+            <x-jet-responsive-nav-link href="{{ route('urls') }}" :active="request()->routeIs('urls')">
+                {{ __('URLs') }}
             </x-jet-responsive-nav-link>
 
             @if(request()->user()->is_admin)

--- a/resources/views/url/index.blade.php
+++ b/resources/views/url/index.blade.php
@@ -1,0 +1,13 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl leading-tight">
+            {{ __('Your shorten URLs') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            @livewire('url.paginated-url-list')
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/url/paginated-url-list.blade.php
+++ b/resources/views/url/paginated-url-list.blade.php
@@ -1,0 +1,23 @@
+<div class="max-w-7xl mx-auto sm:px-6 lg:px-8" wire:poll.10s>
+    <div class="bg-white dark:bg-dark-gray-700 overflow-hidden shadow-xl sm:rounded-lg">
+        <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 dark:text-dark-gray-400">
+            @if($urls->isEmpty())
+                <p class="p-8 col-span-6 text-center">
+                    You don't have any shorten URLs right now, create an <a class="text-indigo-700 dark:text-indigo-400" href="{{ route('api-tokens.index') }}">API token</a> to start shortening URLs.
+                </p>
+            @else
+                @foreach($urls as $url)
+                    @livewire('url.url-preview', [
+                        'url' => $url
+                    ], key($url->id))
+                @endforeach
+            @endif
+        </div>
+
+        @if($urls->hasPages())
+            <div class="p-4 bg-gray-50 dark:bg-dark-gray-800 border-t dark:border-dark-gray-900">
+                {{ $urls->links() }}
+            </div>
+        @endif
+    </div>
+</div>

--- a/resources/views/url/url-preview-list.blade.php
+++ b/resources/views/url/url-preview-list.blade.php
@@ -1,0 +1,38 @@
+<div class="pt-12" wire:poll.10s>
+    <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+        <div class="bg-white dark:bg-dark-gray-900 overflow-hidden shadow-xl sm:rounded-lg">
+            <div class="p-6 flex items-center justify-between bg-white dark:bg-dark-gray-800 border-b border-gray-200 dark:border-dark-gray-500">
+                <div class="text-xl dark:text-dark-gray-100">
+                    Latest shorten URLs
+                </div>
+
+                <a href="#">
+                    <div class="flex items-center text-sm font-semibold text-indigo-700 dark:text-indigo-300">
+                        <div>View all shorten URLs</div>
+
+                        <div class="ml-1 text-indigo-500">
+                            {{-- Heroicon: arrow-right --}}
+                            <svg viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4">
+                                <path fill-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clip-rule="evenodd"></path>
+                            </svg>
+                        </div>
+                    </div>
+                </a>
+            </div>
+
+            <div class="bg-gray-200 dark:bg-dark-gray-700 bg-opacity-25 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6">
+                @if($urls->isEmpty())
+                    <p class="p-8 col-span-6 text-center dark:text-dark-gray-400">
+                        You don't have any shorten URLs right now, create an <a class="text-indigo-700 dark:text-indigo-400" href="{{ route('api-tokens.index') }}">API token</a> to start shortening URLs.
+                    </p>
+                @else
+                    @foreach($urls as $url)
+                        @livewire('url.url-preview', [
+                            'url' => $url
+                        ], key($url->id))
+                    @endforeach
+                @endif
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/url/url-preview-list.blade.php
+++ b/resources/views/url/url-preview-list.blade.php
@@ -6,7 +6,7 @@
                     Latest shorten URLs
                 </div>
 
-                <a href="#">
+                <a href="{{ route('urls') }}">
                     <div class="flex items-center text-sm font-semibold text-indigo-700 dark:text-indigo-300">
                         <div>View all shorten URLs</div>
 

--- a/resources/views/url/url-preview.blade.php
+++ b/resources/views/url/url-preview.blade.php
@@ -1,0 +1,19 @@
+<div class="m-6 flex flex-col">
+    <a class="flex flex-1" href="{{ $url->resource_url }}" target="blank">
+        <div class="p-2 mb-1 flex flex-col w-full text-center overflow-ellipsis dark:bg-dark-gray-800 rounded shadow-md transition duration-500 ease-in-out transform hover:-translate-y-1 hover:scale-110">
+            <img
+                class="flex flex-1"
+                src="{{ route('view-url', [$url, 'preview']) }}"
+                alt="{{ $url->name }}"
+                onerror="this.onerror=null; this.src='{{ asset('vendor/vscode-material-icon-theme/icons/url.svg') }}'"
+            >
+
+            <p class="pt-2 text-xs dark:text-dark-gray-200">Visited {{ $url->visits }} times!</p>
+        </div>
+    </a>
+
+    <div class="p-2 mt-2 items-end grid grid-cols-2 text-center bg-white dark:bg-dark-gray-800 rounded-md border-b border-gray-200 dark:border-dark-gray-900 shadow-md divide-x dark:divide-dark-gray-500">
+        <a class="hover:text-gray-500 dark:text-dark-gray-200 dark:hover:text-dark-gray-400" href="{{ $url->resource_url }}" target="blank">View</a>
+        <a class="text-red-500 hover:text-red-400 cursor-pointer" wire:click="delete">Delete</a>
+    </div>
+</div>

--- a/resources/views/url/url-preview.blade.php
+++ b/resources/views/url/url-preview.blade.php
@@ -8,7 +8,7 @@
                 onerror="this.onerror=null; this.src='{{ asset('vendor/vscode-material-icon-theme/icons/url.svg') }}'"
             >
 
-            <p class="pt-2 text-xs dark:text-dark-gray-200">Visited {{ $url->visits }} times!</p>
+            <p class="pt-2 text-xs dark:text-dark-gray-200">Visited {{ $url->visits }} times</p>
         </div>
     </a>
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api\ImageController;
 use App\Http\Controllers\Api\TextController;
+use App\Http\Controllers\Api\UrlController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -25,5 +26,8 @@ Route::middleware('auth:sanctum')->group(function () {
          ->only(['index', 'show', 'store', 'destroy']);
 
     Route::resource('/texts', TextController::class)
+         ->only(['index', 'show', 'store', 'destroy']);
+
+    Route::resource('/urls', UrlController::class)
          ->only(['index', 'show', 'store', 'destroy']);
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,6 +36,7 @@ Route::middleware(['auth:sanctum', 'verified'])->group(function () {
     Route::view('/dashboard', 'dashboard.index')->name('dashboard');
     Route::view('/images', 'images.index')->name('images');
     Route::view('/texts', 'text.index')->name('texts');
+    Route::view('/urls', 'url.index')->name('urls');
 
     Route::get('/imposter/leave', [ImposterController::class, 'leave'])
          ->name('imposter.leave');

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\ImageController;
 use App\Http\Controllers\ImposterController;
 use App\Http\Controllers\RenderImageController;
 use App\Http\Controllers\RenderTextController;
+use App\Http\Controllers\RenderUrlController;
 use App\Http\Middleware\SiteAdmin;
 use Illuminate\Support\Facades\Route;
 
@@ -27,6 +28,9 @@ Route::get('i/{image}/{type?}', RenderImageController::class)
 Route::get('t/{text}/{raw?}', RenderTextController::class)
      ->where(['raw' => 'raw'])
      ->name('view-text');
+ Route::get('u/{url}/{preview?}', RenderUrlController::class)
+     ->where(['preview' => 'preview'])
+     ->name('view-url');
 
 Route::middleware(['auth:sanctum', 'verified'])->group(function () {
     Route::view('/dashboard', 'dashboard.index')->name('dashboard');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1075,6 +1075,13 @@
   resolved "https://registry.yarnpkg.com/@types/svgo/-/svgo-1.3.4.tgz#75d67b31ed3006c5014c4f810aa300162b68afc8"
   integrity sha512-ru1a0V8k+Z+Hz3oDjJKRElBPt3IvoHx06tU4RRSCDllG+sRhuDULTpdRHRm+rgDeyUWLRjbvMpMLGhYuDU2aQA==
 
+"@types/yauzl@^2.9.1":
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.9.1.tgz#d10f69f9f522eef3cf98e30afb684a1e1ec923af"
+  integrity sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==
+  dependencies:
+    "@types/node" "*"
+
 "@webassemblyjs/ast@1.11.0":
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.0.tgz#a5aa679efdc9e51707a4207139da57920555961f"
@@ -1254,6 +1261,13 @@ acorn@^8.0.4:
   version "8.0.5"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.0.5.tgz#a3bfb872a74a6a7f661bc81b9849d9cac12601b7"
   integrity sha512-v+DieK/HJkJOpFBETDJioequtc3PfxsWMaxIdIwujtF7FEV/MAyDQLlm6/zPvr7Mix07mLh6ccVwIsloceodlg==
+
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -1481,7 +1495,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-js@^1.0.2:
+base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -1525,6 +1539,15 @@ bindings@^1.5.0:
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
     file-uri-to-path "1.0.0"
+
+bl@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9:
   version "4.11.9"
@@ -1677,6 +1700,11 @@ browserslist@*, browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.16.1:
     escalade "^3.1.1"
     node-releases "^1.1.70"
 
+buffer-crc32@~0.2.3:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
+
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
@@ -1700,6 +1728,14 @@ buffer@^4.3.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
+
+buffer@^5.2.1, buffer@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
 
 builtin-status-codes@^3.0.0:
   version "3.0.0"
@@ -1851,6 +1887,11 @@ chokidar@^3.4.3:
     readdirp "~3.5.0"
   optionalDependencies:
     fsevents "~2.3.1"
+
+chownr@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
+  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
 chrome-trace-event@^1.0.2:
   version "1.0.2"
@@ -2362,19 +2403,19 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
+debug@4, debug@^4.1.0, debug@^4.1.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
+
 debug@^3.1.1, debug@^3.2.6:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
-
-debug@^4.1.0:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
-  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
-  dependencies:
-    ms "2.1.2"
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -2484,6 +2525,11 @@ detective@^5.2.0:
     acorn-node "^1.6.1"
     defined "^1.0.0"
     minimist "^1.1.1"
+
+devtools-protocol@0.0.854822:
+  version "0.0.854822"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.854822.tgz#eac3a5260a6b3b4e729a09fdc0c77b0d322e777b"
+  integrity sha512-xd4D8kHQtB0KtWW0c9xBZD5LVtm9chkMOfs/3Yn01RhT/sFIsVtzTtypfKoFfWBaL+7xCYLxjOLkhwPXaX/Kcg==
 
 didyoumean@^1.2.1:
   version "1.2.1"
@@ -2651,6 +2697,13 @@ encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
+
+end-of-stream@^1.1.0, end-of-stream@^1.4.1:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
+  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
+  dependencies:
+    once "^1.4.0"
 
 enhanced-resolve@^5.7.0:
   version "5.7.0"
@@ -2908,6 +2961,17 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+extract-zip@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
+  integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
+  dependencies:
+    debug "^4.1.1"
+    get-stream "^5.1.0"
+    yauzl "^2.10.0"
+  optionalDependencies:
+    "@types/yauzl" "^2.9.1"
+
 fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -2948,6 +3012,13 @@ faye-websocket@^0.11.3:
   integrity sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==
   dependencies:
     websocket-driver ">=0.5.1"
+
+fd-slicer@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
+  integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
+  dependencies:
+    pend "~1.2.0"
 
 file-loader@^6.1.1:
   version "6.2.0"
@@ -3051,6 +3122,11 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
+
 fs-extra@^9.0.1, fs-extra@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
@@ -3107,6 +3183,13 @@ get-intrinsic@^1.0.2:
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.1"
+
+get-stream@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
+  integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
+  dependencies:
+    pump "^3.0.0"
 
 get-stream@^6.0.0:
   version "6.0.0"
@@ -3420,6 +3503,14 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
+https-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
@@ -3437,7 +3528,7 @@ icss-utils@^5.0.0, icss-utils@^5.1.0:
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
   integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
 
-ieee754@^1.1.4:
+ieee754@^1.1.13, ieee754@^1.1.4:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -4304,6 +4395,11 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
+mkdirp-classic@^0.5.2:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
+  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
+
 mkdirp@^0.5.5, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
@@ -4400,6 +4496,11 @@ node-emoji@^1.8.1:
   integrity sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==
   dependencies:
     lodash.toarray "^4.4.0"
+
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-forge@^0.10.0:
   version "0.10.0"
@@ -4592,7 +4693,7 @@ on-headers@~1.0.2:
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
   integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
 
-once@^1.3.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
@@ -4813,6 +4914,11 @@ pbkdf2@^3.0.3:
     ripemd160 "^2.0.1"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
 
 picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
@@ -5245,6 +5351,11 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
+progress@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
 proxy-addr@~2.0.5:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.6.tgz#fdc2336505447d3f2f2c638ed272caf614bbb2bf"
@@ -5252,6 +5363,11 @@ proxy-addr@~2.0.5:
   dependencies:
     forwarded "~0.1.2"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 public-encrypt@^4.0.0:
   version "4.0.3"
@@ -5264,6 +5380,14 @@ public-encrypt@^4.0.0:
     parse-asn1 "^5.0.0"
     randombytes "^2.0.1"
     safe-buffer "^5.1.2"
+
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
 
 punycode@1.3.2:
   version "1.3.2"
@@ -5279,6 +5403,24 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+puppeteer@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-8.0.0.tgz#a236669118aa795331c2d0ca19877159e7664705"
+  integrity sha512-D0RzSWlepeWkxPPdK3xhTcefj8rjah1791GE82Pdjsri49sy11ci/JQsAO8K2NRukqvwEtcI+ImP5F4ZiMvtIQ==
+  dependencies:
+    debug "^4.1.0"
+    devtools-protocol "0.0.854822"
+    extract-zip "^2.0.0"
+    https-proxy-agent "^5.0.0"
+    node-fetch "^2.6.1"
+    pkg-dir "^4.2.0"
+    progress "^2.0.1"
+    proxy-from-env "^1.1.0"
+    rimraf "^3.0.2"
+    tar-fs "^2.0.0"
+    unbzip2-stream "^1.3.3"
+    ws "^7.2.3"
 
 purgecss@^3.1.3:
   version "3.1.3"
@@ -5370,7 +5512,7 @@ readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.3.3, readable
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.0.6, readable-stream@^3.6.0:
+readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -6099,6 +6241,27 @@ tapable@^2.1.1, tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.0.tgz#5c373d281d9c672848213d0e037d1c4165ab426b"
   integrity sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==
 
+tar-fs@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
+  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
+  dependencies:
+    chownr "^1.1.1"
+    mkdirp-classic "^0.5.2"
+    pump "^3.0.0"
+    tar-stream "^2.1.4"
+
+tar-stream@^2.1.4:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
+  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
+  dependencies:
+    bl "^4.0.3"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
+
 terser-webpack-plugin@^5.0.0, terser-webpack-plugin@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.1.1.tgz#7effadee06f7ecfa093dbbd3e9ab23f5f3ed8673"
@@ -6128,6 +6291,11 @@ terser@^5.3.7, terser@^5.5.1:
     commander "^2.20.0"
     source-map "~0.7.2"
     source-map-support "~0.5.19"
+
+through@^2.3.8:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
 thunky@^1.0.2:
   version "1.1.0"
@@ -6215,6 +6383,14 @@ type-is@~1.6.17, type-is@~1.6.18:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
+
+unbzip2-stream@^1.3.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz#b0da04c4371311df771cdc215e87f2130991ace7"
+  integrity sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==
+  dependencies:
+    buffer "^5.2.1"
+    through "^2.3.8"
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
@@ -6592,7 +6768,7 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-ws@^7.4.0:
+ws@^7.2.3, ws@^7.4.0:
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.3.tgz#1f9643de34a543b8edb124bdcbc457ae55a6e5cd"
   integrity sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==
@@ -6634,6 +6810,14 @@ yargs@^16.1.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yauzl@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
+  integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    fd-slicer "~1.1.0"
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
This PR aims to implement #6 by adding support for shortening URLs provided via the API, as-well-as generating previews of those links so it is possible to view the URLs on the dashboard in an easy and friendly way.

**Things to do**

- [x] Create page to view paginated URL previews
- [x] Add support for viewing URL previews on the dashboard
- [x] Add support for deleting URLs
- [x] Add `visit` counter to see how many times a shortened URL has been used 
  - This value should just increment any time the URL is used in the `RenderUrlController`, we don't really care about unique visitors or logging who visits the URL, we only want to know if the link is being used.
- [x] Add validation checks to ensure valid URLs are posted to the API
- [x] Add options in the control panel to manage how long shortened URLs can live