### PR TITLE
Add support for generic file uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,15 @@
 # PHP & Composer
 /vendor
 /storage/*.key
+/storage/debugbar
 .phpunit.result.cache
+.php-cs-fixer.cache
+.phpstorm.meta.php
+.php_cs.cache
+_ide_*.php
 .env.backup
 .env
-
-# PHP CS
-.php_cs.cache
+.rnd
 
 # NPM & Mix
 /node_modules

--- a/app/Console/Commands/MediaCleanupCommand.php
+++ b/app/Console/Commands/MediaCleanupCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Models\File;
 use App\Models\Image;
 use App\Models\Text;
 use App\Models\Url;
@@ -55,6 +56,8 @@ class MediaCleanupCommand extends Command
         $this->cleanupTextFiles();
 
         $this->cleanupUrls();
+
+        $this->cleanupFiles();
     }
 
     /**
@@ -117,6 +120,30 @@ class MediaCleanupCommand extends Command
         $this->info('Starting cleanup process for ' . $total . ' shorten URLs!');
 
         $query->delete();
+
+        $this->info('Done!');
+    }
+
+    /**
+     * Cleans up the expired files.
+     *
+     * @return void
+     */
+    protected function cleanupFiles()
+    {
+        $query = File::where('created_at', '<', $this->createTimestampFor('files'));
+        $total = $query->count();
+
+        if ($total == 0) {
+            return $this->warn('No files to cleanup, skipping...');
+        }
+
+        $this->info('Starting cleanup process for ' . $total . ' files!');
+
+        foreach ($query->cursor() as $file) {
+            $file->delete();
+        }
+
 
         $this->info('Done!');
     }

--- a/app/Http/Controllers/Api/FileController.php
+++ b/app/Http/Controllers/Api/FileController.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\File;
+use Illuminate\Http\Request;
+
+class FileController extends Controller
+{
+    /**
+     * Setup the file policy used in the controller for authorization.
+     */
+    public function __construct()
+    {
+        $this->authorizeResource(File::class);
+    }
+
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        return File::simplePaginate(10);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        $file = File::createAndSave($request->file('file'));
+
+        if ($request->header('Accept') == 'text/plain') {
+            $file = $file->resource_url;
+        }
+
+        return response($file, 201);
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \App\Models\File  $file
+     * @return \Illuminate\Http\Response
+     */
+    public function show(File $file)
+    {
+        return $file;
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \App\Models\File  $file
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(File $file)
+    {
+        $file->delete();
+
+        return response(null, 204);
+    }
+}

--- a/app/Http/Controllers/RenderFileController.php
+++ b/app/Http/Controllers/RenderFileController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\File;
+use App\Scopes\UserScope;
+
+class RenderFileController extends Controller
+{
+    /**
+     * Handle the incoming request.
+     *
+     * @param  string $id
+     * @param  string|null $type
+     * @return \Illuminate\Http\Response
+     */
+    public function __invoke($id, $raw = null)
+    {
+        $file = $this->loadFileOrFail($id);
+
+        return response($file->content);
+    }
+
+    /**
+     * Loads the file with the given name, or fails trying.
+     *
+     * @param  string $name
+     * @return \App\Models\File
+     */
+    protected function loadFileOrFail($name)
+    {
+        $parts = explode('.', $name);
+
+        $file = File::withoutGlobalScope(UserScope::class)
+            ->where('name', array_shift($parts))
+            ->firstOrFail();
+
+        if (count($parts) > 0) {
+            abort_unless($parts[0] == $file->extension, 404);
+        }
+
+        return $file;
+    }
+}

--- a/app/Http/Controllers/RenderFileController.php
+++ b/app/Http/Controllers/RenderFileController.php
@@ -18,6 +18,13 @@ class RenderFileController extends Controller
     {
         $file = $this->loadFileOrFail($id);
 
+        if (!$raw) {
+            return view('preview.file', [
+                'file' => $file,
+            ]);
+        }
+
+        // TODO: Download the actual file here...
         return response($file->content);
     }
 

--- a/app/Http/Controllers/RenderFileController.php
+++ b/app/Http/Controllers/RenderFileController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\File;
 use App\Scopes\UserScope;
+use Illuminate\Support\Facades\Storage;
 
 class RenderFileController extends Controller
 {
@@ -24,8 +25,10 @@ class RenderFileController extends Controller
             ]);
         }
 
-        // TODO: Download the actual file here...
-        return response($file->content);
+        return Storage::download(
+            'files/' . $file->getResourceName(),
+            $file->original_name
+        );
     }
 
     /**

--- a/app/Http/Livewire/ControlPanel/UpdateFileSettingsForm.php
+++ b/app/Http/Livewire/ControlPanel/UpdateFileSettingsForm.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Http\Livewire\ControlPanel;
+
+use Livewire\Component;
+
+class UpdateFileSettingsForm extends Component
+{
+    /**
+     * The text settings.
+     *
+     * @var array
+     */
+    public $settings;
+
+    /**
+     * The validation rules for the component.
+     *
+     * @var array
+     */
+    protected $rules = [
+        'settings.ttl_days' => 'required|numeric|min:0',
+        'settings.ttl_hours' => 'required|numeric|min:0',
+        'settings.ttl_minutes' => 'required|numeric|min:0',
+        'settings.per_page' => 'required|numeric|min:1',
+    ];
+
+    /**
+     * List of validation attribute names that are more human friendly.
+     *
+     * @var array
+     */
+    protected $validationAttributes = [
+        'settings.ttl_days' => 'TTL days',
+        'settings.ttl_hours' => 'TTL hours',
+        'settings.ttl_minutes' => 'TTL minutes',
+        'settings.per_page' => 'text uploads per page',
+    ];
+
+    /**
+     * Prepare the component.
+     *
+     * @return void
+     */
+    public function mount()
+    {
+        $settings = app('settings');
+
+        $this->settings = [
+            'ttl_days' => $settings->get('files.ttl_days'),
+            'ttl_hours' => $settings->get('files.ttl_hours'),
+            'ttl_minutes' => $settings->get('files.ttl_minutes'),
+            'per_page' => $settings->get('files.per_page'),
+        ];
+    }
+
+    /**
+     * Update the text settings.
+     *
+     * @return void
+     */
+    public function updateFileSettings()
+    {
+        $this->validate();
+
+        $manager = app('settings');
+
+        foreach ($this->settings as $name => $value) {
+            $manager->set('files.' . $name, $value);
+        }
+
+        $this->emit('saved');
+    }
+
+    /**
+     * Render the component.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function render()
+    {
+        return view('control-panel.update-file-settings-form');
+    }
+}

--- a/app/Http/Livewire/Dashboard/Stats.php
+++ b/app/Http/Livewire/Dashboard/Stats.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Livewire\Dashboard;
 
+use App\Models\File;
 use App\Models\Image;
 use App\Models\Text;
 use App\Models\Url;
@@ -43,6 +44,7 @@ class Stats extends Component
             return [
                 'images' => Image::count(),
                 'texts' => Text::count(),
+                'files' => File::count(),
                 'urls' => Url::count(),
             ];
         });

--- a/app/Http/Livewire/Files/FilePreview.php
+++ b/app/Http/Livewire/Files/FilePreview.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Livewire\Files;
+
+use Livewire\Component;
+
+class FilePreview extends Component
+{
+    /**
+     * The file the component previews.
+     *
+     * @var \App\Models\File
+     */
+    public $file;
+
+    /**
+     * Deletes the file associated with the component.
+     *
+     * @return void
+     */
+    public function delete()
+    {
+        $this->file->delete();
+
+        $this->emitUp('fileDeleted');
+    }
+
+    /**
+     * Render the component.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function render()
+    {
+        return view('files.file-preview');
+    }
+}

--- a/app/Http/Livewire/Files/FilePreviewList.php
+++ b/app/Http/Livewire/Files/FilePreviewList.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Livewire\Files;
+
+use App\Models\File;
+use Livewire\Component;
+
+class FilePreviewList extends Component
+{
+    /**
+     * The events the component should listen for.
+     *
+     * @var array
+     */
+    protected $listeners = ['fileDeleted' => '$refresh'];
+
+    /**
+     * Render the component.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function render()
+    {
+        return view('files.file-preview-list', [
+            'files' => File::latest()
+                ->limit(6)
+                ->get(),
+        ]);
+    }
+}

--- a/app/Http/Livewire/Files/PaginatedFilesList.php
+++ b/app/Http/Livewire/Files/PaginatedFilesList.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Livewire\Files;
+
+use Livewire\Component;
+
+class PaginatedFilesList extends Component
+{
+    /**
+     * Render the component.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function render()
+    {
+        return view('files.paginated-files-list');
+    }
+}

--- a/app/Http/Livewire/Files/PaginatedFilesList.php
+++ b/app/Http/Livewire/Files/PaginatedFilesList.php
@@ -2,10 +2,21 @@
 
 namespace App\Http\Livewire\Files;
 
+use App\Models\File;
 use Livewire\Component;
+use Livewire\WithPagination;
 
 class PaginatedFilesList extends Component
 {
+    use WithPagination;
+
+    /**
+     * The events the component should listen for.
+     *
+     * @var array
+     */
+    protected $listeners = ['fileDeleted' => '$refresh'];
+
     /**
      * Render the component.
      *
@@ -13,6 +24,8 @@ class PaginatedFilesList extends Component
      */
     public function render()
     {
-        return view('files.paginated-files-list');
+        return view('files.paginated-files-list', [
+            'files' => File::latest()->paginate(app('settings')->get('files.per_page')),
+        ]);
     }
 }

--- a/app/Http/Livewire/Files/UploadFileModalForm.php
+++ b/app/Http/Livewire/Files/UploadFileModalForm.php
@@ -2,16 +2,57 @@
 
 namespace App\Http\Livewire\Files;
 
+use App\Models\File;
 use Livewire\Component;
+use Livewire\WithFileUploads;
 
 class UploadFileModalForm extends Component
 {
+    use WithFileUploads;
+
     /**
      * Determines if the modal should be shown to the user.
      *
      * @var boolean
      */
     public $showModal = false;
+
+
+    /**
+     * The file that should be uploaded.
+     *
+     * @var mixed
+     */
+    public $file = null;
+
+    /**
+     * Handle state changes when the model is toggled.
+     *
+     * @param  bool $state
+     * @return void
+     */
+    public function updatedShowModal($state)
+    {
+        if (!$state) {
+            $this->resetErrorBag();
+        }
+    }
+
+    /**
+     * Handles uploading and saving the file.
+     *
+     * @return
+     */
+    public function save()
+    {
+        if ($this->file) {
+            $file = File::createAndSave($this->file);
+
+            session()->flash('upload-url', $file->resource_url);
+        }
+
+        $this->reset('file');
+    }
 
     /**
      * Render the component.

--- a/app/Http/Livewire/Files/UploadFileModalForm.php
+++ b/app/Http/Livewire/Files/UploadFileModalForm.php
@@ -26,6 +26,16 @@ class UploadFileModalForm extends Component
     public $file = null;
 
     /**
+     * Hydrates the component.
+     *
+     * @return void
+     */
+    public function hydrate()
+    {
+        $this->resetErrorBag();
+    }
+
+    /**
      * Handle state changes when the model is toggled.
      *
      * @param  bool $state
@@ -45,6 +55,8 @@ class UploadFileModalForm extends Component
      */
     public function save()
     {
+        $this->resetErrorBag();
+
         if ($this->file) {
             $file = File::createAndSave($this->file);
 

--- a/app/Http/Livewire/Files/UploadFileModalForm.php
+++ b/app/Http/Livewire/Files/UploadFileModalForm.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Livewire\Files;
+
+use Livewire\Component;
+
+class UploadFileModalForm extends Component
+{
+    /**
+     * Determines if the modal should be shown to the user.
+     *
+     * @var boolean
+     */
+    public $showModal = false;
+
+    /**
+     * Render the component.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function render()
+    {
+        return view('files.upload-file-modal-form');
+    }
+}

--- a/app/Jobs/CalculateUsedDiskSpace.php
+++ b/app/Jobs/CalculateUsedDiskSpace.php
@@ -48,6 +48,7 @@ class CalculateUsedDiskSpace implements ShouldQueue
     public function handle()
     {
         $this->calculateImageDiskSize()
+            ->calculateFileDiskSize()
             ->calculateTextDiskSize()
             ->calculateUrlDiskSize()
             ->saveTotalSpaceUsed();
@@ -79,6 +80,21 @@ class CalculateUsedDiskSpace implements ShouldQueue
                     storage_path('app/images/' . $image->getResourceName($size . 'x' . $size))
                 );
             }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Calculate the total amount of disk space
+     * used up by files for the given user.
+     *
+     * @return self
+     */
+    protected function calculateFileDiskSize()
+    {
+        foreach ($this->user->files()->cursor() as $file) {
+            $this->totalSize += filesize(storage_path('app/files/' . $file->getResourceName()));
         }
 
         return $this;

--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -65,4 +65,23 @@ class File extends Model
     {
         return $this->belongsTo(User::class, 'user_id');
     }
+
+    /**
+     * Get the formatted version of the size in with the matching
+     * size unit appended to the end of the size.
+     *
+     * @return string
+     */
+    public function getFormattedSizeAttribute()
+    {
+        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+
+        $bytes = max($this->size, 0);
+        $pow = floor(($bytes ? log($bytes) : 0) / log(1024));
+        $pow = min($pow, count($units) - 1);
+
+        $bytes /= pow(1024, $pow);
+
+        return round($bytes, 1) . ' ' . $units[$pow];
+    }
 }

--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\BelongsToUser;
+use App\Traits\FileExtensionIcon;
+use App\Traits\MediaResource;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\UploadedFile;
+
+class File extends Model
+{
+    use HasFactory;
+    use MediaResource;
+    use BelongsToUser;
+    use FileExtensionIcon;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'user_id',
+        'name',
+        'extension',
+        'size',
+        'hash_md5',
+        'hash_sha1',
+    ];
+
+    /**
+     * The name of the route used to view the resource directly.
+     *
+     * @var string
+     */
+    protected $resourceViewRoute = 'view-file';
+
+    /**
+     * The API resource name, this is the API resource name
+     * used when registering the route in the API.
+     *
+     * @var string
+     */
+    protected $resourceApiName = 'files';
+
+    /**
+     * Creates a new text entry, and stores the uploaded file.
+     *
+     * @param  \Illuminate\Http\UploadedFile $file
+     * @return \App\Models\File
+     */
+    public static function createAndSave(UploadedFile $file)
+    {
+        //
+    }
+
+    /**
+     * The belongs to relationship between the file and the user who owns it.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function owner()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -59,6 +59,16 @@ class User extends Authenticatable
     }
 
     /**
+     * The has many relationship between the user and the files they have uploaded.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function files()
+    {
+        return $this->hasMany(File::class)->withoutGlobalScopes();
+    }
+
+    /**
      * The has many relationship between the user and the texts they have uploaded.
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasMany

--- a/app/Observers/FileObserver.php
+++ b/app/Observers/FileObserver.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Observers;
+
+use App\Jobs\CalculateUsedDiskSpace;
+use App\Models\File;
+use Cache;
+use Storage;
+
+class FileObserver
+{
+    /**
+     * Handle the File "created" event.
+     *
+     * @param  \App\Models\File  $file
+     * @return void
+     */
+    public function created(File $file)
+    {
+        CalculateUsedDiskSpace::dispatch(request()->user());
+
+        Cache::forget('dashboard.stats::' . request()->user()->id);
+    }
+
+    /**
+     * Handle the File "deleted" event.
+     *
+     * @param  \App\Models\File  $file
+     * @return void
+     */
+    public function deleted(File $file)
+    {
+        Storage::delete('files/' . $file->getResourceName());
+
+        Cache::forget('dashboard.stats::' . request()->user()->id);
+
+        CalculateUsedDiskSpace::dispatch(request()->user());
+    }
+}

--- a/app/Policies/FilePolicy.php
+++ b/app/Policies/FilePolicy.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\File;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class FilePolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any models.
+     *
+     * @param  \App\Models\User  $user
+     * @return mixed
+     */
+    public function viewAny(User $user)
+    {
+        return $user->tokenCan('file:list');
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\File  $file
+     * @return mixed
+     */
+    public function view(User $user, File $file)
+    {
+        return $user->tokenCan('file:view') && $user->id == $file->user_id;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     *
+     * @param  \App\Models\User  $user
+     * @return mixed
+     */
+    public function create(User $user)
+    {
+        return $user->tokenCan('file:upload');
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\File  $file
+     * @return mixed
+     */
+    public function delete(User $user, File $file)
+    {
+        return $user->tokenCan('file:delete') && $user->id == $file->user_id;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,9 +2,11 @@
 
 namespace App\Providers;
 
+use App\Models\File;
 use App\Models\Image;
 use App\Models\Text;
 use App\Models\Url;
+use App\Observers\FileObserver;
 use App\Observers\ImageObserver;
 use App\Observers\TextObserver;
 use App\Observers\UrlObserver;
@@ -37,6 +39,7 @@ class AppServiceProvider extends ServiceProvider
 
         Image::observe(ImageObserver::class);
         Text::observe(TextObserver::class);
+        File::observe(FileObserver::class);
         Url::observe(UrlObserver::class);
     }
 }

--- a/app/Providers/JetstreamServiceProvider.php
+++ b/app/Providers/JetstreamServiceProvider.php
@@ -41,6 +41,7 @@ class JetstreamServiceProvider extends ServiceProvider
             'image:upload',
             'text:upload',
             'url:upload',
+            'file:upload',
         ]);
 
         Jetstream::permissions([
@@ -56,6 +57,10 @@ class JetstreamServiceProvider extends ServiceProvider
             'url:list',
             'url:upload',
             'url:delete',
+            'file:view',
+            'file:list',
+            'file:upload',
+            'file:delete',
         ]);
     }
 }

--- a/app/Settings/SettingsManager.php
+++ b/app/Settings/SettingsManager.php
@@ -33,6 +33,11 @@ class SettingsManager
         'urls.ttl_hours' => 0,
         'urls.ttl_minutes' => 0,
         'urls.per_page' => 24,
+
+        'files.ttl_days' => 90,
+        'files.ttl_hours' => 0,
+        'files.ttl_minutes' => 0,
+        'files.per_page' => 24,
     ];
 
     /**

--- a/app/Traits/FileExtensionIcon.php
+++ b/app/Traits/FileExtensionIcon.php
@@ -21,6 +21,7 @@ trait FileExtensionIcon
         'typescript' => ['ts', 'd.ts'],
         'python' => ['py'],
         'git' => ['git-commit', 'git-rebase', 'ignore'],
+        'zip' => ['zip', 'ear', 'war', 'rar', 'jar', '7z'],
         'settings' => [
             'properties',
             'editorconfig',

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.5",
+        "barryvdh/laravel-ide-helper": "^2.10",
         "facade/ignition": "^2.5",
         "fakerphp/faker": "^1.9.1",
         "laravel/sail": "^1.0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dce19bb8d4ab90bc286c13e9a06e83e5",
+    "content-hash": "e7474d65114c128677f2e9257887a450",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -6078,6 +6078,1033 @@
             "time": "2021-04-07T11:19:20+00:00"
         },
         {
+            "name": "barryvdh/laravel-ide-helper",
+            "version": "v2.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/laravel-ide-helper.git",
+                "reference": "73b1012b927633a1b4cd623c2e6b1678e6faef08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/laravel-ide-helper/zipball/73b1012b927633a1b4cd623c2e6b1678e6faef08",
+                "reference": "73b1012b927633a1b4cd623c2e6b1678e6faef08",
+                "shasum": ""
+            },
+            "require": {
+                "barryvdh/reflection-docblock": "^2.0.6",
+                "composer/composer": "^1.6 || ^2",
+                "doctrine/dbal": "^2.6 || ^3",
+                "ext-json": "*",
+                "illuminate/console": "^8",
+                "illuminate/filesystem": "^8",
+                "illuminate/support": "^8",
+                "nikic/php-parser": "^4.7",
+                "php": "^7.3 || ^8.0",
+                "phpdocumentor/type-resolver": "^1.1.0"
+            },
+            "require-dev": {
+                "ext-pdo_sqlite": "*",
+                "friendsofphp/php-cs-fixer": "^2",
+                "illuminate/config": "^8",
+                "illuminate/view": "^8",
+                "mockery/mockery": "^1.4",
+                "orchestra/testbench": "^6",
+                "phpunit/phpunit": "^8.5 || ^9",
+                "spatie/phpunit-snapshot-assertions": "^3 || ^4",
+                "vimeo/psalm": "^3.12"
+            },
+            "suggest": {
+                "illuminate/events": "Required for automatic helper generation (^6|^7|^8)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.9-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Barryvdh\\LaravelIdeHelper\\IdeHelperServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Barryvdh\\LaravelIdeHelper\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "Laravel IDE Helper, generates correct PHPDocs for all Facade classes, to improve auto-completion.",
+            "keywords": [
+                "autocomplete",
+                "codeintel",
+                "helper",
+                "ide",
+                "laravel",
+                "netbeans",
+                "phpdoc",
+                "phpstorm",
+                "sublime"
+            ],
+            "support": {
+                "issues": "https://github.com/barryvdh/laravel-ide-helper/issues",
+                "source": "https://github.com/barryvdh/laravel-ide-helper/tree/v2.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-04-09T06:17:55+00:00"
+        },
+        {
+            "name": "barryvdh/reflection-docblock",
+            "version": "v2.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/ReflectionDocBlock.git",
+                "reference": "6b69015d83d3daf9004a71a89f26e27d27ef6a16"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/ReflectionDocBlock/zipball/6b69015d83d3daf9004a71a89f26e27d27ef6a16",
+                "reference": "6b69015d83d3daf9004a71a89f26e27d27ef6a16",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0,<4.5"
+            },
+            "suggest": {
+                "dflydev/markdown": "~1.0",
+                "erusev/parsedown": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Barryvdh": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "mike.vanriel@naenius.com"
+                }
+            ],
+            "support": {
+                "source": "https://github.com/barryvdh/ReflectionDocBlock/tree/v2.0.6"
+            },
+            "time": "2018-12-13T10:34:14+00:00"
+        },
+        {
+            "name": "composer/ca-bundle",
+            "version": "1.2.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/ca-bundle.git",
+                "reference": "9fdb22c2e97a614657716178093cd1da90a64aa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/9fdb22c2e97a614657716178093cd1da90a64aa8",
+                "reference": "9fdb22c2e97a614657716178093cd1da90a64aa8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "ext-pcre": "*",
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.55",
+                "psr/log": "^1.0",
+                "symfony/phpunit-bridge": "^4.2 || ^5",
+                "symfony/process": "^2.5 || ^3.0 || ^4.0 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\CaBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
+            "keywords": [
+                "cabundle",
+                "cacert",
+                "certificate",
+                "ssl",
+                "tls"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/ca-bundle/issues",
+                "source": "https://github.com/composer/ca-bundle/tree/1.2.10"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-06-07T13:58:28+00:00"
+        },
+        {
+            "name": "composer/composer",
+            "version": "2.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/composer.git",
+                "reference": "fc5c4573aafce3a018eb7f1f8f91cea423970f2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/composer/zipball/fc5c4573aafce3a018eb7f1f8f91cea423970f2e",
+                "reference": "fc5c4573aafce3a018eb7f1f8f91cea423970f2e",
+                "shasum": ""
+            },
+            "require": {
+                "composer/ca-bundle": "^1.0",
+                "composer/metadata-minifier": "^1.0",
+                "composer/semver": "^3.0",
+                "composer/spdx-licenses": "^1.2",
+                "composer/xdebug-handler": "^2.0",
+                "justinrainbow/json-schema": "^5.2.10",
+                "php": "^5.3.2 || ^7.0 || ^8.0",
+                "psr/log": "^1.0",
+                "react/promise": "^1.2 || ^2.7",
+                "seld/jsonlint": "^1.4",
+                "seld/phar-utils": "^1.0",
+                "symfony/console": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
+                "symfony/filesystem": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
+                "symfony/finder": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
+                "symfony/process": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0"
+            },
+            "require-dev": {
+                "phpspec/prophecy": "^1.10",
+                "symfony/phpunit-bridge": "^4.2 || ^5.0 || ^6.0"
+            },
+            "suggest": {
+                "ext-openssl": "Enabling the openssl extension allows you to access https URLs for repositories and packages",
+                "ext-zip": "Enabling the zip extension allows you to unzip archives",
+                "ext-zlib": "Allow gzip compression of HTTP requests"
+            },
+            "bin": [
+                "bin/composer"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\": "src/Composer"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "https://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Composer helps you declare, manage and install dependencies of PHP projects. It ensures you have the right stack everywhere.",
+            "homepage": "https://getcomposer.org/",
+            "keywords": [
+                "autoload",
+                "dependency",
+                "package"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/composer/issues",
+                "source": "https://github.com/composer/composer/tree/2.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-06-09T14:31:20+00:00"
+        },
+        {
+            "name": "composer/metadata-minifier",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/metadata-minifier.git",
+                "reference": "c549d23829536f0d0e984aaabbf02af91f443207"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/metadata-minifier/zipball/c549d23829536f0d0e984aaabbf02af91f443207",
+                "reference": "c549d23829536f0d0e984aaabbf02af91f443207",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2",
+                "phpstan/phpstan": "^0.12.55",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\MetadataMinifier\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Small utility library that handles metadata minification and expansion.",
+            "keywords": [
+                "composer",
+                "compression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/metadata-minifier/issues",
+                "source": "https://github.com/composer/metadata-minifier/tree/1.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-04-07T13:37:33+00:00"
+        },
+        {
+            "name": "composer/package-versions-deprecated",
+            "version": "1.11.99.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/package-versions-deprecated.git",
+                "reference": "c6522afe5540d5fc46675043d3ed5a45a740b27c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/c6522afe5540d5fc46675043d3ed5a45a740b27c",
+                "reference": "c6522afe5540d5fc46675043d3ed5a45a740b27c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1.0 || ^2.0",
+                "php": "^7 || ^8"
+            },
+            "replace": {
+                "ocramius/package-versions": "1.11.99"
+            },
+            "require-dev": {
+                "composer/composer": "^1.9.3 || ^2.0@dev",
+                "ext-zip": "^1.13",
+                "phpunit/phpunit": "^6.5 || ^7"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "support": {
+                "issues": "https://github.com/composer/package-versions-deprecated/issues",
+                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-24T07:46:03+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "31f3ea725711245195f62e54ffa402d8ef2fdba9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/31f3ea725711245195f62e54ffa402d8ef2fdba9",
+                "reference": "31f3ea725711245195f62e54ffa402d8ef2fdba9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.54",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.2.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-24T12:41:47+00:00"
+        },
+        {
+            "name": "composer/spdx-licenses",
+            "version": "1.5.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/spdx-licenses.git",
+                "reference": "de30328a7af8680efdc03e396aad24befd513200"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/de30328a7af8680efdc03e396aad24befd513200",
+                "reference": "de30328a7af8680efdc03e396aad24befd513200",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Spdx\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "SPDX licenses list and validation library.",
+            "keywords": [
+                "license",
+                "spdx",
+                "validator"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/spdx-licenses/issues",
+                "source": "https://github.com/composer/spdx-licenses/tree/1.5.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-12-03T16:04:16+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "964adcdd3a28bf9ed5d9ac6450064e0d71ed7496"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/964adcdd3a28bf9ed5d9ac6450064e0d71ed7496",
+                "reference": "964adcdd3a28bf9ed5d9ac6450064e0d71ed7496",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.55",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-05T19:37:51+00:00"
+        },
+        {
+            "name": "doctrine/cache",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "c9622c6820d3ede1e2315a6a377ea1076e421d88"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/c9622c6820d3ede1e2315a6a377ea1076e421d88",
+                "reference": "c9622c6820d3ede1e2315a6a377ea1076e421d88",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4",
+                "psr/cache": ">=3"
+            },
+            "require-dev": {
+                "alcaeus/mongo-php-adapter": "^1.1",
+                "cache/integration-tests": "dev-master",
+                "doctrine/coding-standard": "^8.0",
+                "mongodb/mongodb": "^1.1",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
+                "predis/predis": "~1.0",
+                "psr/cache": "^1.0 || ^2.0",
+                "symfony/cache": "^4.4 || ^5.2"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Cache library is a popular cache implementation that supports many different drivers such as redis, memcache, apc, mongodb and others.",
+            "homepage": "https://www.doctrine-project.org/projects/cache.html",
+            "keywords": [
+                "abstraction",
+                "apcu",
+                "cache",
+                "caching",
+                "couchdb",
+                "memcached",
+                "php",
+                "redis",
+                "xcache"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/cache/issues",
+                "source": "https://github.com/doctrine/cache/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fcache",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-25T09:43:04+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "8e0fde2b90e3f61361013d1e928621beeea07bc0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/8e0fde2b90e3f61361013d1e928621beeea07bc0",
+                "reference": "8e0fde2b90e3f61361013d1e928621beeea07bc0",
+                "shasum": ""
+            },
+            "require": {
+                "composer/package-versions-deprecated": "^1.11.99",
+                "doctrine/cache": "^1.0|^2.0",
+                "doctrine/deprecations": "^0.5.3",
+                "doctrine/event-manager": "^1.0",
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "9.0.0",
+                "jetbrains/phpstorm-stubs": "2020.2",
+                "phpstan/phpstan": "0.12.81",
+                "phpstan/phpstan-strict-rules": "^0.12.2",
+                "phpunit/phpunit": "9.5.5",
+                "psalm/plugin-phpunit": "0.13.0",
+                "squizlabs/php_codesniffer": "3.6.0",
+                "symfony/cache": "^5.2|^6.0",
+                "symfony/console": "^2.0.5|^3.0|^4.0|^5.0|^6.0",
+                "vimeo/psalm": "4.6.4"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\DBAL\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+            "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+            "keywords": [
+                "abstraction",
+                "database",
+                "db2",
+                "dbal",
+                "mariadb",
+                "mssql",
+                "mysql",
+                "oci8",
+                "oracle",
+                "pdo",
+                "pgsql",
+                "postgresql",
+                "queryobject",
+                "sasql",
+                "sql",
+                "sqlite",
+                "sqlserver",
+                "sqlsrv"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/dbal/issues",
+                "source": "https://github.com/doctrine/dbal/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdbal",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-06-19T17:59:55+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "v0.5.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "9504165960a1f83cc1480e2be1dd0a0478561314"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/9504165960a1f83cc1480e2be1dd0a0478561314",
+                "reference": "9504165960a1f83cc1480e2be1dd0a0478561314",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0|^7.0|^8.0",
+                "phpunit/phpunit": "^7.0|^8.0|^9.0",
+                "psr/log": "^1.0"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/v0.5.3"
+            },
+            "time": "2021-03-21T12:59:47+00:00"
+        },
+        {
+            "name": "doctrine/event-manager",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/event-manager.git",
+                "reference": "41370af6a30faa9dc0368c4a6814d596e81aba7f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/41370af6a30faa9dc0368c4a6814d596e81aba7f",
+                "reference": "41370af6a30faa9dc0368c4a6814d596e81aba7f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/common": "<2.9@dev"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "The Doctrine Event Manager is a simple PHP event system that was built to be used with the various Doctrine projects.",
+            "homepage": "https://www.doctrine-project.org/projects/event-manager.html",
+            "keywords": [
+                "event",
+                "event dispatcher",
+                "event manager",
+                "event system",
+                "events"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/event-manager/issues",
+                "source": "https://github.com/doctrine/event-manager/tree/1.1.x"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fevent-manager",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-29T18:28:51+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.4.0",
             "source": {
@@ -6527,6 +7554,76 @@
                 "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
             },
             "time": "2020-07-09T08:09:16+00:00"
+        },
+        {
+            "name": "justinrainbow/json-schema",
+            "version": "5.2.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/justinrainbow/json-schema.git",
+                "reference": "2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b",
+                "reference": "2ba9c8c862ecd5510ed16c6340aa9f6eadb4f31b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",
+                "json-schema/json-schema-test-suite": "1.2.0",
+                "phpunit/phpunit": "^4.8.35"
+            },
+            "bin": [
+                "bin/validate-json"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JsonSchema\\": "src/JsonSchema/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bruno Prieto Reis",
+                    "email": "bruno.p.reis@gmail.com"
+                },
+                {
+                    "name": "Justin Rainbow",
+                    "email": "justin.rainbow@gmail.com"
+                },
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                },
+                {
+                    "name": "Robert Schönthal",
+                    "email": "seroscho@googlemail.com"
+                }
+            ],
+            "description": "A library to validate a json schema.",
+            "homepage": "https://github.com/justinrainbow/json-schema",
+            "keywords": [
+                "json",
+                "schema"
+            ],
+            "support": {
+                "issues": "https://github.com/justinrainbow/json-schema/issues",
+                "source": "https://github.com/justinrainbow/json-schema/tree/5.2.10"
+            },
+            "time": "2020-05-27T16:41:55+00:00"
         },
         {
             "name": "laravel/sail",
@@ -7629,6 +8726,56 @@
             "time": "2021-03-23T07:16:29+00:00"
         },
         {
+            "name": "react/promise",
+            "version": "v2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "f3cff96a19736714524ca0dd1d4130de73dbbbc4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/f3cff96a19736714524ca0dd1d4130de73dbbbc4",
+                "reference": "f3cff96a19736714524ca0dd1d4130de73dbbbc4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0 || ^6.5 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise/issues",
+                "source": "https://github.com/reactphp/promise/tree/v2.8.0"
+            },
+            "time": "2020-05-12T15:16:56+00:00"
+        },
+        {
             "name": "sebastian/cli-parser",
             "version": "1.0.1",
             "source": {
@@ -8593,6 +9740,117 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
+            "name": "seld/jsonlint",
+            "version": "1.8.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/jsonlint.git",
+                "reference": "9ad6ce79c342fbd44df10ea95511a1b24dee5b57"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/9ad6ce79c342fbd44df10ea95511a1b24dee5b57",
+                "reference": "9ad6ce79c342fbd44df10ea95511a1b24dee5b57",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+            },
+            "bin": [
+                "bin/jsonlint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Seld\\JsonLint\\": "src/Seld/JsonLint/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "JSON Linter",
+            "keywords": [
+                "json",
+                "linter",
+                "parser",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/jsonlint/issues",
+                "source": "https://github.com/Seldaek/jsonlint/tree/1.8.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/seld/jsonlint",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-11T09:19:24+00:00"
+        },
+        {
+            "name": "seld/phar-utils",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/phar-utils.git",
+                "reference": "8674b1d84ffb47cc59a101f5d5a3b61e87d23796"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/phar-utils/zipball/8674b1d84ffb47cc59a101f5d5a3b61e87d23796",
+                "reference": "8674b1d84ffb47cc59a101f5d5a3b61e87d23796",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Seld\\PharUtils\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "PHAR file format utilities, for when PHP phars you up",
+            "keywords": [
+                "phar"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/phar-utils/issues",
+                "source": "https://github.com/Seldaek/phar-utils/tree/master"
+            },
+            "time": "2020-07-07T18:42:57+00:00"
+        },
+        {
             "name": "symfony/debug",
             "version": "v4.4.20",
             "source": {
@@ -8660,6 +9918,68 @@
                 }
             ],
             "time": "2021-01-28T16:54:48+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v5.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "348116319d7fb7d1faa781d26a48922428013eb2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/348116319d7fb7d1faa781d26a48922428013eb2",
+                "reference": "348116319d7fb7d1faa781d26a48922428013eb2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v5.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-26T17:43:10+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -8773,5 +10093,5 @@
         "php": "^7.3|^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/config/livewire.php
+++ b/config/livewire.php
@@ -83,7 +83,7 @@ return [
 
     'temporary_file_upload' => [
         'disk' => null,        // Example: 'local', 's3'              Default: 'default'
-        'rules' => null,       // Example: ['file', 'mimes:png,jpg']  Default: ['required', 'file', 'max:12288'] (12MB)
+        'rules' => ['required', 'file'], // Example: ['file', 'mimes:png,jpg']  Default: ['required', 'file', 'max:12288'] (12MB)
         'directory' => null,   // Example: 'tmp'                      Default  'livewire-tmp'
         'middleware' => null,  // Example: 'throttle:5,1'             Default: 'throttle:60,1'
         'preview_mimes' => [   // Supported file types for temporary pre-signed file URLs.

--- a/database/factories/FileFactory.php
+++ b/database/factories/FileFactory.php
@@ -26,6 +26,7 @@ class FileFactory extends Factory
         return [
             'user_id' => User::factory(),
             'name' => Str::random(10),
+            'original_name' => $this->faker->name,
             'extension' => 'zip',
             'size' => function () {
                 return \rand(100, 9999999);

--- a/database/factories/FileFactory.php
+++ b/database/factories/FileFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\File;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Str;
+
+class FileFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = File::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'user_id' => User::factory(),
+            'name' => Str::random(10),
+            'extension' => 'zip',
+            'size' => function () {
+                return \rand(100, 9999999);
+            },
+            'hash_md5' => function () {
+                return \md5(\rand(100, 9999999));
+            },
+            'hash_sha1' => function () {
+                return \sha1(\rand(100, 9999999));
+            },
+        ];
+    }
+}

--- a/database/migrations/2021_06_26_133619_create_files_table.php
+++ b/database/migrations/2021_06_26_133619_create_files_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFilesTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('files', function (Blueprint $table) {
+            $table->id();
+            $table
+                ->foreignId('user_id')
+                ->constrained()
+                ->onDelete('cascade');
+            $table
+                ->string('name')
+                ->unique()
+                ->index();
+            $table->string('extension', 12);
+            $table->integer('size')->unsigned();
+            $table->string('hash_md5', 32);
+            $table->string('hash_sha1', 40);
+            $table->timestamps();
+
+            $table->unique(['user_id', 'name']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('files');
+    }
+}

--- a/database/migrations/2021_06_26_133619_create_files_table.php
+++ b/database/migrations/2021_06_26_133619_create_files_table.php
@@ -18,6 +18,7 @@ class CreateFilesTable extends Migration
                 ->string('name')
                 ->unique()
                 ->index();
+            $table->string('original_name');
             $table->string('extension', 12);
             $table->integer('size')->unsigned();
             $table->string('hash_md5', 32);

--- a/resources/views/control-panel/index.blade.php
+++ b/resources/views/control-panel/index.blade.php
@@ -26,7 +26,7 @@
                             'underline bg-gray-800 dark:bg-dark-gray-700': active == 'image',
                             'bg-gray-700 dark:bg-dark-gray-800 hover:bg-gray-500 dark:hover:bg-dark-gray-600': active != 'image'
                         }"
-                       class="px-3 py-1.5 mx-2 rounded dark:bg-dark-gray-800 text-sm cursor-pointer text-white dark:text-gray-600 dark:text-dark-gray-400">
+                       class="px-3 py-1.5 mx-2 rounded dark:bg-dark-gray-800 text-sm cursor-pointer text-white dark:text-dark-gray-400">
                         Images
                     </a>
                     <a
@@ -35,7 +35,7 @@
                             'underline bg-gray-800 dark:bg-dark-gray-700': active == 'text',
                             'bg-gray-700 dark:bg-dark-gray-800 hover:bg-gray-500 dark:hover:bg-dark-gray-600': active != 'text'
                         }"
-                       class="px-3 py-1.5 mx-2 rounded dark:bg-dark-gray-800 text-sm cursor-pointer text-white dark:text-gray-600 dark:text-dark-gray-400">
+                       class="px-3 py-1.5 mx-2 rounded dark:bg-dark-gray-800 text-sm cursor-pointer text-white dark:text-dark-gray-400">
                         Texts
                     </a>
                     <a
@@ -44,8 +44,17 @@
                             'underline bg-gray-800 dark:bg-dark-gray-700': active == 'url',
                             'bg-gray-700 dark:bg-dark-gray-800 hover:bg-gray-500 dark:hover:bg-dark-gray-600': active != 'url'
                         }"
-                       class="px-3 py-1.5 mx-2 rounded dark:bg-dark-gray-800 text-sm cursor-pointer text-white dark:text-gray-600 dark:text-dark-gray-400">
+                       class="px-3 py-1.5 mx-2 rounded dark:bg-dark-gray-800 text-sm cursor-pointer text-white dark:text-dark-gray-400">
                         URLs
+                    </a>
+                    <a
+                       x-on:click="active = 'file'"
+                       :class="{
+                            'underline bg-gray-800 dark:bg-dark-gray-700': active == 'file',
+                            'bg-gray-700 dark:bg-dark-gray-800 hover:bg-gray-500 dark:hover:bg-dark-gray-600': active != 'file'
+                        }"
+                       class="px-3 py-1.5 mx-2 rounded dark:bg-dark-gray-800 text-sm cursor-pointer text-white dark:text-dark-gray-400">
+                        Files
                     </a>
                 </div>
 
@@ -59,6 +68,10 @@
 
                 <div x-show="active == 'url'" class="mt-10 sm:mt-0">
                     @livewire('control-panel.update-url-settings-form')
+                </div>
+
+                <div x-show="active == 'file'" class="mt-10 sm:mt-0">
+                    @livewire('control-panel.update-file-settings-form')
                 </div>
             </div>
 

--- a/resources/views/control-panel/index.blade.php
+++ b/resources/views/control-panel/index.blade.php
@@ -39,15 +39,6 @@
                         Texts
                     </a>
                     <a
-                       x-on:click="active = 'url'"
-                       :class="{
-                            'underline bg-gray-800 dark:bg-dark-gray-700': active == 'url',
-                            'bg-gray-700 dark:bg-dark-gray-800 hover:bg-gray-500 dark:hover:bg-dark-gray-600': active != 'url'
-                        }"
-                       class="px-3 py-1.5 mx-2 rounded dark:bg-dark-gray-800 text-sm cursor-pointer text-white dark:text-dark-gray-400">
-                        URLs
-                    </a>
-                    <a
                        x-on:click="active = 'file'"
                        :class="{
                             'underline bg-gray-800 dark:bg-dark-gray-700': active == 'file',
@@ -55,6 +46,15 @@
                         }"
                        class="px-3 py-1.5 mx-2 rounded dark:bg-dark-gray-800 text-sm cursor-pointer text-white dark:text-dark-gray-400">
                         Files
+                    </a>
+                    <a
+                       x-on:click="active = 'url'"
+                       :class="{
+                            'underline bg-gray-800 dark:bg-dark-gray-700': active == 'url',
+                            'bg-gray-700 dark:bg-dark-gray-800 hover:bg-gray-500 dark:hover:bg-dark-gray-600': active != 'url'
+                        }"
+                       class="px-3 py-1.5 mx-2 rounded dark:bg-dark-gray-800 text-sm cursor-pointer text-white dark:text-dark-gray-400">
+                        URLs
                     </a>
                 </div>
 
@@ -66,12 +66,12 @@
                     @livewire('control-panel.update-text-settings-form')
                 </div>
 
-                <div x-show="active == 'url'" class="mt-10 sm:mt-0">
-                    @livewire('control-panel.update-url-settings-form')
-                </div>
-
                 <div x-show="active == 'file'" class="mt-10 sm:mt-0">
                     @livewire('control-panel.update-file-settings-form')
+                </div>
+
+                <div x-show="active == 'url'" class="mt-10 sm:mt-0">
+                    @livewire('control-panel.update-url-settings-form')
                 </div>
             </div>
 

--- a/resources/views/control-panel/update-file-settings-form.blade.php
+++ b/resources/views/control-panel/update-file-settings-form.blade.php
@@ -1,0 +1,41 @@
+<x-jet-form-section submit="updateFileSettings">
+    <x-slot name="title">
+        {{ __('File Settings') }}
+    </x-slot>
+
+    <x-slot name="description">
+        {{ __('Change how file are handled and displayed on the site.') }}
+    </x-slot>
+
+    <x-slot name="form">
+        <!-- TTL -->
+        <div class="col-span-6 sm:col-span-4">
+            <x-jet-label for="file_ttl_days" value="{{ __('File Live Time (Days, Hours and Minutes)') }}" />
+            <div class="flex space-x-3">
+                <x-jet-input id="file_ttl_days" type="number" class="mt-1 block w-full" min="0" wire:model.defer="settings.ttl_days" />
+                <x-jet-input id="file_ttl_hours" type="number" class="mt-1 block w-full" min="0" wire:model.defer="settings.ttl_hours" />
+                <x-jet-input id="file_ttl_minutes" type="number" class="mt-1 block w-full" min="0" wire:model.defer="settings.ttl_minutes" />
+            </div>
+            <x-jet-input-error for="settings.ttl_days" class="mt-2" />
+            <x-jet-input-error for="settings.ttl_hours" class="mt-2" />
+            <x-jet-input-error for="settings.ttl_minutes" class="mt-2" />
+        </div>
+
+        <!-- Per page -->
+        <div class="col-span-6 sm:col-span-4">
+            <x-jet-label for="file_per_page" value="{{ __('Files per page') }}" />
+            <x-jet-input id="file_per_page" type="number" class="mt-1 block w-full" min="1" wire:model.defer="settings.per_page" />
+            <x-jet-input-error for="settings.per_page" class="mt-2" />
+        </div>
+    </x-slot>
+
+    <x-slot name="actions">
+        <x-jet-action-message class="mr-3" on="saved">
+            {{ __('Saved.') }}
+        </x-jet-action-message>
+
+        <x-jet-button wire:loading.attr="disabled" wire:target="photo">
+            {{ __('Save') }}
+        </x-jet-button>
+    </x-slot>
+</x-jet-form-section>

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -11,5 +11,7 @@
 
     @livewire('text.text-preview-list')
 
+    @livewire('files.file-preview-list')
+
     @livewire('url.url-preview-list')
 </x-app-layout>

--- a/resources/views/dashboard/stats.blade.php
+++ b/resources/views/dashboard/stats.blade.php
@@ -1,5 +1,5 @@
 <div class="pt-12">
-    <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 grid grid-cols-4 sm:space-x-4">
+    <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 grid grid-cols-2 lg:grid-cols-5 sm:gap-4">
         <div class="p-6 bg-white dark:bg-dark-gray-800 bg-opacity-25 sm:shadow-xl sm:rounded-lg">
             <div class="flex justify-center items-center space-x-8">
                 <div>
@@ -11,7 +11,7 @@
                     </div>
                 </div>
                 <!-- Heroicons : photograph -->
-                <svg class="hidden sm:block h-16 w-16 text-gray-400 dark:text-dark-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                <svg class="h-16 w-16 text-gray-400 dark:text-dark-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"
                      xmlns="http://www.w3.org/2000/svg">
                     <path stroke-linecap="round"
                           stroke-linejoin="round"
@@ -33,13 +33,34 @@
                     </div>
                 </div>
                 <!-- Heroicons : document-text -->
-                <svg class="hidden sm:block h-16 w-16 text-gray-400 dark:text-dark-gray-400"
+                <svg class="h-16 w-16 text-gray-400 dark:text-dark-gray-400"
                      fill="none"
                      stroke="currentColor"
                      viewBox="0 0 24 24"
                      xmlns="http://www.w3.org/2000/svg">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                           d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+                </svg>
+            </div>
+        </div>
+
+        <div class="p-6 bg-white dark:bg-dark-gray-800 bg-opacity-25 sm:shadow-xl sm:rounded-lg">
+            <div class="flex justify-center items-center space-x-8">
+                <div>
+                    <div class="uppercase text-sm text-gray-400 dark:text-dark-gray-400">
+                        Files
+                    </div>
+                    <div class="mt-1 text-5xl font-bold dark:text-dark-gray-200">
+                        {{ number_format($files) }}
+                    </div>
+                </div>
+                <!-- Heroicons : document-duplicate -->
+                <svg class="h-16 w-16 text-gray-400 dark:text-dark-gray-400"
+                     fill="currentColor"
+                     viewBox="0 0 20 20"
+                     xmlns="http://www.w3.org/2000/svg">
+                    <path d="M9 2a2 2 0 00-2 2v8a2 2 0 002 2h6a2 2 0 002-2V6.414A2 2 0 0016.414 5L14 2.586A2 2 0 0012.586 2H9z"></path>
+                    <path d="M3 8a2 2 0 012-2v10h8a2 2 0 01-2 2H5a2 2 0 01-2-2V8z"></path>
                 </svg>
             </div>
         </div>
@@ -55,7 +76,7 @@
                     </div>
                 </div>
                 <!-- Heroicons : link -->
-                <svg class="hidden sm:block h-16 w-16 text-gray-400 dark:text-dark-gray-400"
+                <svg class="h-16 w-16 text-gray-400 dark:text-dark-gray-400"
                      fill="none"
                      stroke="currentColor"
                      viewBox="0 0 24 24"
@@ -69,7 +90,7 @@
             </div>
         </div>
 
-        <div class="p-6 bg-white dark:bg-dark-gray-800 bg-opacity-25 sm:shadow-xl sm:rounded-lg">
+        <div class="p-6 bg-white dark:bg-dark-gray-800 bg-opacity-25 sm:shadow-xl sm:rounded-lg col-span-2 lg:col-span-1">
             <div class="flex justify-center items-center space-x-8">
                 <div>
                     <div class="uppercase text-sm text-gray-400 dark:text-dark-gray-400">
@@ -77,7 +98,7 @@
                     </div>
                     <div class="mt-1 text-5xl font-bold dark:text-dark-gray-200">
                         {{ $disk['size'] }}
-                        <span class="text-3xl">
+                        <span class="text-xl">
                             {{ $disk['unit'] }}
                         </span>
                     </div>

--- a/resources/views/files/file-preview-list.blade.php
+++ b/resources/views/files/file-preview-list.blade.php
@@ -1,0 +1,38 @@
+<div class="pt-12" wire:poll.10s>
+    <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+        <div class="bg-white dark:bg-dark-gray-900 overflow-hidden shadow-xl sm:rounded-lg">
+            <div class="p-6 flex items-center justify-between bg-white dark:bg-dark-gray-800 border-b border-gray-200 dark:border-dark-gray-500">
+                <div class="text-xl dark:text-dark-gray-100">
+                    Latest file uploads
+                </div>
+
+                <a href="{{ route('files') }}">
+                    <div class="flex items-center text-sm font-semibold text-indigo-700 dark:text-indigo-300">
+                        <div>View all files</div>
+
+                        <div class="ml-1 text-indigo-500">
+                            {{-- Heroicon: arrow-right --}}
+                            <svg viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4">
+                                <path fill-rule="evenodd"
+                                      d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                                      clip-rule="evenodd"></path>
+                            </svg>
+                        </div>
+                    </div>
+                </a>
+            </div>
+
+            <div class="bg-gray-200 dark:bg-dark-gray-700 bg-opacity-25 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6">
+                @if ($files->isEmpty())
+                    <x-has-no-media :type="'image'" />
+                @else
+                    @foreach ($files as $file)
+                        @livewire('files.file-preview', [
+                        'file' => $file
+                        ], key($file->id))
+                    @endforeach
+                @endif
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/files/file-preview.blade.php
+++ b/resources/views/files/file-preview.blade.php
@@ -1,0 +1,23 @@
+<div class="m-6 flex flex-col">
+    <a class="flex flex-1" href="{{ $file->resource_url }}" target="blank">
+        <div
+             class="p-2 mb-1 flex flex-col w-full text-center overflow-ellipsis dark:bg-dark-gray-800 rounded shadow-md transition duration-500 ease-in-out transform hover:-translate-y-1 hover:scale-110">
+            <img
+                 class="flex flex-1"
+                 loading="lazy"
+                 height="256"
+                 width="256"
+                 src="{{ asset('vendor/vscode-material-icon-theme/icons/' . $file->file_icon . '.svg') }}"
+                 alt="{{ $file->original_name }}"
+                 onerror="this.onerror=null; this.src='{{ asset('vendor/vscode-material-icon-theme/icons/url.svg') }}'">
+
+            <p class="pt-2 text-xs dark:text-dark-gray-200 overflow-hidden overflow-ellipsis">{{ $file->original_name }}</p>
+        </div>
+    </a>
+
+    <div
+         class="p-2 mt-2 items-end grid grid-cols-2 text-center bg-white dark:bg-dark-gray-800 rounded-md border-b border-gray-200 dark:border-dark-gray-900 shadow-md divide-x dark:divide-dark-gray-500">
+        <a class="hover:text-gray-500 dark:text-dark-gray-200 dark:hover:text-dark-gray-400" href="{{ $file->resource_url }}" target="blank">View</a>
+        <a class="text-red-500 hover:text-red-400 cursor-pointer" wire:click="delete">Delete</a>
+    </div>
+</div>

--- a/resources/views/files/index.blade.php
+++ b/resources/views/files/index.blade.php
@@ -1,0 +1,17 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex justify-between">
+            <h2 class="font-semibold text-xl leading-tight">
+                {{ __('Your Files') }}
+            </h2>
+
+            @livewire('files.upload-file-modal-form')
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            @livewire('files.paginated-files-list')
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/files/paginated-files-list.blade.php
+++ b/resources/views/files/paginated-files-list.blade.php
@@ -1,0 +1,3 @@
+<div>
+    {{-- To attain knowledge, add things every day; To attain wisdom, subtract things every day --}}
+</div>

--- a/resources/views/files/paginated-files-list.blade.php
+++ b/resources/views/files/paginated-files-list.blade.php
@@ -1,3 +1,19 @@
-<div>
-    {{-- To attain knowledge, add things every day; To attain wisdom, subtract things every day --}}
+<div class="max-w-7xl mx-auto sm:px-6 lg:px-8" wire:poll.10s>
+    <div class="bg-white dark:bg-dark-gray-700 overflow-hidden shadow-xl sm:rounded-lg">
+        <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 dark:text-dark-gray-400">
+            @if ($files->isEmpty())
+                <x-has-no-media :type="'file'" />
+            @else
+                @foreach ($files as $file)
+                    @livewire('files.file-preview', ['file' => $file], key($file->id))
+                @endforeach
+            @endif
+        </div>
+
+        @if ($files->hasPages())
+            <div class="p-4 bg-gray-50 dark:bg-dark-gray-800 border-t dark:border-dark-gray-900">
+                {{ $files->links() }}
+            </div>
+        @endif
+    </div>
 </div>

--- a/resources/views/files/upload-file-modal-form.blade.php
+++ b/resources/views/files/upload-file-modal-form.blade.php
@@ -1,0 +1,5 @@
+<div>
+    <x-jet-button wire:click="$set('showModal', true)">
+        Upload File
+    </x-jet-button>
+</div>

--- a/resources/views/files/upload-file-modal-form.blade.php
+++ b/resources/views/files/upload-file-modal-form.blade.php
@@ -2,4 +2,77 @@
     <x-jet-button wire:click="$set('showModal', true)">
         Upload File
     </x-jet-button>
+
+    <x-jet-dialog-modal wire:model="showModal">
+        <x-slot name="title">
+            {{ __('Upload file') }}
+        </x-slot>
+
+        <x-slot name="content">
+            @if (session()->has('upload-url'))
+                <div class="pb-4">
+                    <p class="pb-2">
+                        The file has been uploaded successfully, you can copy the link below to share the file with other people.
+                    </p>
+                    <x-jet-input class="w-full rounded" type="text"
+                                 value="{{ session('upload-url') }}"
+                                 onfocus="this.select()" autofocus readonly
+                                 autocomplete="off" autocorrect="off"
+                                 autocapitalize="off" spellcheck="false" />
+                </div>
+            @endif
+
+            <div>
+                {{ __('Select the file you want to upload.') }}
+            </div>
+
+            <div class="col-span-6 sm:col-span-4"
+                 x-data="{ isUploading: false, progress: 0 }"
+                 x-on:livewire-upload-start="isUploading = true"
+                 x-on:livewire-upload-finish="isUploading = false"
+                 x-on:livewire-upload-error="isUploading = false"
+                 x-on:livewire-upload-progress="progress = $event.detail.progress">
+                <input type="file" class="hidden"
+                       wire:model="file"
+                       x-ref="file" />
+
+                <div class="flex items-center">
+                    <x-jet-secondary-button class="mt-2 mr-2"
+                                            type="button"
+                                            wire:loading.attr="disabled"
+                                            x-on:click.prevent="$refs.file.click()">
+                        {{ __('Select an file to upload') }}
+                    </x-jet-secondary-button>
+                </div>
+
+                @if ($file)
+                    <p class="py-2">{{ $file->getClientOriginalName() }}</p>
+                @endif
+
+                <div x-show="isUploading" class="pt-4 opacity-75">
+                    <div class="w-96 h-3 bg-indigo-200 dark:bg-dark-gray-500 rounded shadow">
+                        <div class="h-3 bg-indigo-500 rounded" :style="['width: ' + progress + '%']"></div>
+                    </div>
+                </div>
+
+                <x-jet-input-error for="file" class="mt-2" />
+            </div>
+        </x-slot>
+
+        <x-slot name="footer">
+            <x-jet-secondary-button wire:click="$set('showModal', false)" wire:loading.attr="disabled">
+                {{ __('Close') }}
+            </x-jet-secondary-button>
+
+            @if ($file)
+                <x-jet-button class="ml-2" wire:click="save" wire:loading.attr="disabled">
+                    {{ __('Save File') }}
+                </x-jet-button>
+            @else
+                <x-jet-button class="ml-2" wire:click="save" wire:loading.attr="disabled" disabled="true">
+                    {{ __('Save File') }}
+                </x-jet-button>
+            @endif
+        </x-slot>
+    </x-jet-dialog-modal>
 </div>

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -28,6 +28,10 @@
                         {{ __('URLs') }}
                     </x-jet-nav-link>
 
+                    <x-jet-nav-link href="{{ route('files') }}" :active="request()->routeIs('files')">
+                        {{ __('Files') }}
+                    </x-jet-nav-link>
+
                     @if (request()->user()->is_admin)
                         <x-jet-nav-link href="{{ route('control-panel') }}" :active="request()->routeIs('control-panel')">
                             {{ __('Control Panel') }}
@@ -148,6 +152,10 @@
 
             <x-jet-responsive-nav-link href="{{ route('urls') }}" :active="request()->routeIs('urls')">
                 {{ __('URLs') }}
+            </x-jet-responsive-nav-link>
+
+            <x-jet-responsive-nav-link href="{{ route('files') }}" :active="request()->routeIs('files')">
+                {{ __('Files') }}
             </x-jet-responsive-nav-link>
 
             @if (request()->user()->is_admin)

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -24,12 +24,12 @@
                         {{ __('Texts') }}
                     </x-jet-nav-link>
 
-                    <x-jet-nav-link href="{{ route('urls') }}" :active="request()->routeIs('urls')">
-                        {{ __('URLs') }}
-                    </x-jet-nav-link>
-
                     <x-jet-nav-link href="{{ route('files') }}" :active="request()->routeIs('files')">
                         {{ __('Files') }}
+                    </x-jet-nav-link>
+
+                    <x-jet-nav-link href="{{ route('urls') }}" :active="request()->routeIs('urls')">
+                        {{ __('URLs') }}
                     </x-jet-nav-link>
 
                     @if (request()->user()->is_admin)
@@ -150,12 +150,12 @@
                 {{ __('Texts') }}
             </x-jet-responsive-nav-link>
 
-            <x-jet-responsive-nav-link href="{{ route('urls') }}" :active="request()->routeIs('urls')">
-                {{ __('URLs') }}
-            </x-jet-responsive-nav-link>
-
             <x-jet-responsive-nav-link href="{{ route('files') }}" :active="request()->routeIs('files')">
                 {{ __('Files') }}
+            </x-jet-responsive-nav-link>
+
+            <x-jet-responsive-nav-link href="{{ route('urls') }}" :active="request()->routeIs('urls')">
+                {{ __('URLs') }}
             </x-jet-responsive-nav-link>
 
             @if (request()->user()->is_admin)
@@ -244,7 +244,8 @@
                         {{ __('Switch Teams') }}
                     </div>
 
-                    @foreach (request()->user()->allTeams() as $team)
+                    @foreach (request()->user()->allTeams()
+    as $team)
                         <x-jet-switchable-team :team="$team" component="jet-responsive-nav-link" />
                     @endforeach
                 @endif

--- a/resources/views/preview/file.blade.php
+++ b/resources/views/preview/file.blade.php
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>{{ app('settings')->get('app.name') }} - Download {{ $file->original_name }}</title>
+    <meta property="og:title" content="{{ $file->original_name }}">
+    <meta property="og:type" content="website">
+    <meta property="og:description"
+          content="Download page for {{ $file->original_name }}, file size: {{ $file->formatted_size }}, file hash: {{ $file->hash_sha1 }}">
+
+    <!-- Styles -->
+    <link rel="stylesheet" href="{{ mix('css/app.css') }}">
+</head>
+
+<body class="h-screen flex items-center justify-center bg-gray-900 text-gray-50">
+
+    <div class="flex flex-col">
+        <div class="flex bg-gray-700 rounded-md shadow-lg">
+            <div class="p-4">
+                <img
+                     class="w-32 h-32"
+                     loading="lazy"
+                     src="{{ asset('vendor/vscode-material-icon-theme/icons/' . $file->file_icon . '.svg') }}"
+                     alt="{{ $file->original_name }}"
+                     onerror="this.onerror=null; this.src='{{ asset('vendor/vscode-material-icon-theme/icons/file.svg') }}'">
+            </div>
+            <div class="py-4 pr-6 justify-self-center">
+                <h1 class="text-lg leading-6 font-semibold">{{ $file->original_name }}</h1>
+                <div class="pt-3 flex flex-col">
+                    <p class="text-gray-400 font-mono">
+                        <span class="text-gray-300 font-medium">File size:</span>
+                        {{ $file->formatted_size }}
+                    </p>
+                    <p class="pt-3 text-gray-400 font-mono">
+                        <span class="text-gray-300 font-medium pr-2">MD5 Hash:</span>
+                        {{ $file->hash_md5 }}
+                    </p>
+                    <p class="text-gray-400 font-mono">
+                        <span class="text-gray-300 font-medium">SHA1 Hash:</span>
+                        {{ $file->hash_sha1 }}
+                    </p>
+                </div>
+            </div>
+        </div>
+
+        <div class="pt-6 flex justify-center">
+            <a href="{{ route('view-file', [$file->name, 'raw']) }}"
+               class="px-4 py-2 text-lg bg-indigo-500 hover:bg-indigo-400 rounded shadow">
+                Download {{ $file->original_name }}
+            </a>
+        </div>
+    </div>
+
+</body>
+
+</html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\FileController;
 use App\Http\Controllers\Api\ImageController;
 use App\Http\Controllers\Api\TextController;
 use App\Http\Controllers\Api\UrlController;
@@ -23,11 +24,14 @@ Route::middleware('auth:sanctum')->group(function () {
     });
 
     Route::resource('images', ImageController::class)
-         ->only(['index', 'show', 'store', 'destroy']);
+          ->only(['index', 'show', 'store', 'destroy']);
 
     Route::resource('texts', TextController::class)
-         ->only(['index', 'show', 'store', 'destroy']);
+          ->only(['index', 'show', 'store', 'destroy']);
 
     Route::resource('urls', UrlController::class)
-         ->only(['index', 'show', 'store', 'destroy']);
+          ->only(['index', 'show', 'store', 'destroy']);
+
+    Route::resource('files', FileController::class)
+          ->only(['index', 'show', 'store', 'destroy']);
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\ImposterController;
+use App\Http\Controllers\RenderFileController;
 use App\Http\Controllers\RenderImageController;
 use App\Http\Controllers\RenderTextController;
 use App\Http\Controllers\RenderUrlController;
@@ -29,6 +30,9 @@ Route::get('t/{text}/{raw?}', RenderTextController::class)
 Route::get('u/{url}/{preview?}', RenderUrlController::class)
      ->where(['preview' => 'preview'])
      ->name('view-url');
+Route::get('f/{file}/{raw?}', RenderFileController::class)
+     ->where(['raw' => 'raw'])
+     ->name('view-file');
 
 Route::middleware(['auth:sanctum', 'verified'])->group(function () {
     Route::view('dashboard', 'dashboard.index')->name('dashboard');
@@ -38,12 +42,12 @@ Route::middleware(['auth:sanctum', 'verified'])->group(function () {
     Route::view('files', 'files.index')->name('files');
 
     Route::get('imposter/leave', [ImposterController::class, 'leave'])
-         ->name('imposter.leave');
+          ->name('imposter.leave');
     Route::get('imposter/{user}', [ImposterController::class, 'join'])
-        ->middleware(SiteAdmin::class)
-        ->name('imposter.join');
+          ->middleware(SiteAdmin::class)
+          ->name('imposter.join');
 
     Route::view('control-panel', 'control-panel.index')
-        ->middleware(SiteAdmin::class)
-        ->name('control-panel');
+          ->middleware(SiteAdmin::class)
+          ->name('control-panel');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,6 +35,7 @@ Route::middleware(['auth:sanctum', 'verified'])->group(function () {
     Route::view('images', 'images.index')->name('images');
     Route::view('texts', 'text.index')->name('texts');
     Route::view('urls', 'url.index')->name('urls');
+    Route::view('files', 'files.index')->name('files');
 
     Route::get('imposter/leave', [ImposterController::class, 'leave'])
          ->name('imposter.leave');


### PR DESCRIPTION
This adds support for generic file uploads that don't match the existing categories like images, files and shorten URLs, files uploaded as generic files will be previewed when accessed with an icon matching the file type, and some information about the file such as its name, file size, MD5 and SHA1 hashes, this PR is based off the suggestion in #20.

TODO List:

- [x] Create file preview before downloading them.
    - The preview should include the icon matching the file extension, and some general information about the file such as the original name, file size, and hashes.
- [x] Create files observer to delete files from disk.
- [x] Add file settings to the control panel.
- [x] Add file scopes to the API tokens page.
- [x] Add support for uploading files via the UI.
- [x] Add support for uploading files via the API.
- [x] Ensure all UI components works in both light and dark mode